### PR TITLE
Fixing relative imports and setup config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 init:
 	pip install -r requirements.txt
+	pip install -e .
 
 test:
 	py.test tests

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,2 +1,2 @@
-from .logger import setup_logging
+from client.logger import setup_logging
 setup_logging()

--- a/client/api.py
+++ b/client/api.py
@@ -1,7 +1,7 @@
 import Pyro4
 import Pyro4.errors
-from .scheduler import Scheduler
-from .job import Job, ProcessExecutable
+from client.scheduler import Scheduler
+from client.job import Job, ProcessExecutable
 
 
 class Api(object):

--- a/client/client.py
+++ b/client/client.py
@@ -2,9 +2,9 @@ import Pyro4
 import logging
 import sys
 import socket
-from .api import Api
-from .logger import setup_logging
-from .scheduler import start_scheduler
+from client.api import Api
+from client.logger import setup_logging
+from client.scheduler import start_scheduler
 
 
 def get_logger():

--- a/client/notifiers.py
+++ b/client/notifiers.py
@@ -1,5 +1,5 @@
-from .job import Job
-from .oauth import TokenStore, Token
+from client.job import Job
+from client.oauth import TokenStore, Token
 from http import HTTPStatus
 import logging
 import requests

--- a/client/scheduler.py
+++ b/client/scheduler.py
@@ -8,7 +8,7 @@ from typing import Callable  # For self-documenting typing
 import Pyro4  # For daemon management
 import psutil  # For verifying ports if Errno 98
 import socket  # To verify daemon
-from .job import Job  # Defines scheduler jobs
+from client.job import Job  # Defines scheduler jobs
 
 # Worker thread reading from queue and waiting for processes to finish
 def read_queue(q: queue.Queue, do_work, stop_event: threading.Event) -> None:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup, find_packages
+
+setup(name="Meeshkan Client", packages=find_packages())

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import client

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-from .context import client
+import client
 from client.config import get_secrets, get_config
 from pathlib import Path
 

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -1,4 +1,4 @@
-from .context import client
+import client
 from client.notifiers import CloudNotifier, Payload, post_payloads
 from client.oauth import TokenStore
 from client.job import Job, Executable

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,4 +1,4 @@
-from .context import client
+import client
 from client.oauth import TokenStore, token_source
 from .test_notifiers import _MockResponse
 import pytest

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-from .context import client
+import client
 from client.scheduler import Scheduler
 from client.job import Job, JobStatus, Executable
 from concurrent.futures import Future, wait


### PR DESCRIPTION
Adding setup.py with minimal contents (can add some requirements to it as well).
Removed relative imports (some left in tests but that's okay).
Imports within the directory now follow the "python" way of import the package (i.e. `import client.logger` instead of `import logger`).
`tests/context.py` also removed as it was no longer needed