### PR TITLE
Separate command for help, supplements -h and --help.

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -82,7 +82,7 @@ def help_cmd(ctx):
     print(ctx.parent.get_help())
 
 
-@cli.command(name='start')
+@cli.command()
 def start():
     """Initializes the scheduler daemon."""
     config, credentials = __get_auth()


### PR DESCRIPTION
Allows running `meeshkan help` when stuff is setup.