### PR TITLE
Enforce suffcient code coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ steps:
   displayName: 'Installing dev version'
 
 - script: |
-    pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=client --cov-report=xml --cov-report=html --cov-fail-under=80
+    pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=meeshkan --cov-report=xml --cov-report=html --cov-fail-under=80
   displayName: 'Test with pytest'
 
 - script: |


### PR DESCRIPTION
- Currently set to 80% coverage is around 80.6 %. 
- If required by fast development, one can just lower the required require to be able to build. But I think that should be a conscious choice instead of letting coverage fall silently
- [x]  Rebase once https://github.com/Meeshkan/meeshkan-client/pull/30 is merged