### PR TITLE
Silence urllib3 debug log, do not log for tasks.

### DIFF
--- a/meeshkan/logging.yaml
+++ b/meeshkan/logging.yaml
@@ -33,6 +33,10 @@ handlers:
         backupCount: 20
         encoding: utf8
 
+loggers:
+    urllib3.connectionpool:
+        level: WARNING
+
 root:
     level: DEBUG
     handlers: [debug_file_handler, info_file_handler, error_file_handler]

--- a/meeshkan/scheduler.py
+++ b/meeshkan/scheduler.py
@@ -210,7 +210,8 @@ class Scheduler(object):
 
     async def _handle_task(self, task: meeshkan.tasks.Task):
         # TODO Do something with the item
-        LOGGER.debug("Got task for job ID %s, task type %s", task.job_id, task.type.name)
+        # LOGGER.debug("Got task for job ID %s, task type %s", task.job_id, task.type.name)
+        pass
 
     async def poll(self):
         await self._task_poller.poll(handle_task=self._handle_task)


### PR DESCRIPTION
Regular polling currently produces quite a bit of DEBUG log, get rid of some of that.