### PR TITLE
Set multiproc start method to spawn, serialize build_api.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include meeshkan/*.yaml
+include meeshkan/core/*.yaml

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ meeshkan list
 meeshkan stop
 ```
 
+## Reporting scalars from PyTorch
+See [examples/pytorch_mnist.py](./examples/pytorch_mnist.py) for an example script. To run the script,
+first ensure that [PyTorch]() is installed in your Python environment. Then submit the example as
+ ```bash
+meeshkan submit --poll 10 examples/pytorch_mnist.py
+```
+Meeshkan reports the training and test loss values to you every 10 seconds.
+
+
 ## Development
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ meeshkan stop
 ```
 
 ## Reporting scalars from PyTorch
+
+### Get started
+Start the service first, then run
+``` bash
+meeshkan submit --poll 10 examples/report.py
+```
+
+### PyTorch
 See [examples/pytorch_mnist.py](./examples/pytorch_mnist.py) for an example script. To run the script,
 first ensure that [PyTorch]() is installed in your Python environment. Then submit the example as
  ```bash

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -1,0 +1,120 @@
+from __future__ import print_function
+import argparse
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torchvision import datasets, transforms
+
+import meeshkan
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
+        self.conv2_drop = nn.Dropout2d()
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+def train(args, model, device, train_loader, optimizer, epoch):
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+
+        meeshkan.report_scalar("train loss", loss.item())  # Added to report training loss
+
+        loss.backward()
+        optimizer.step()
+        if batch_idx % args.log_interval == 0:
+            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                epoch, batch_idx * len(data), len(train_loader.dataset),
+                100. * batch_idx / len(train_loader), loss.item()))
+
+
+def test(args, model, device, test_loader):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction='sum').item() # sum up batch loss
+            pred = output.max(1, keepdim=True)[1] # get the index of the max log-probability
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+
+    meeshkan.report_scalar("test loss", test_loss.item())  # added to report test loss
+
+    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        test_loss, correct, len(test_loader.dataset),
+        100. * correct / len(test_loader.dataset)))
+
+
+def main():
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=10, metavar='N',
+                        help='number of epochs to train (default: 10)')
+    parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
+                        help='learning rate (default: 0.01)')
+    parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
+                        help='SGD momentum (default: 0.5)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--log-interval', type=int, default=10, metavar='N',
+                        help='how many batches to wait before logging training status')
+    args = parser.parse_args()
+    use_cuda = not args.no_cuda and torch.cuda.is_available()
+
+    torch.manual_seed(args.seed)
+
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}
+    train_loader = torch.utils.data.DataLoader(
+        datasets.MNIST('../data', train=True, download=True,
+                       transform=transforms.Compose([
+                           transforms.ToTensor(),
+                           transforms.Normalize((0.1307,), (0.3081,))
+                       ])),
+        batch_size=args.batch_size, shuffle=True, **kwargs)
+    test_loader = torch.utils.data.DataLoader(
+        datasets.MNIST('../data', train=False, transform=transforms.Compose([
+                           transforms.ToTensor(),
+                           transforms.Normalize((0.1307,), (0.3081,))
+                       ])),
+        batch_size=args.test_batch_size, shuffle=True, **kwargs)
+
+    model = Net().to(device)
+    optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+
+    for epoch in range(1, args.epochs + 1):
+        train(args, model, device, train_loader, optimizer, epoch)
+        test(args, model, device, test_loader)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/report.py
+++ b/examples/report.py
@@ -1,0 +1,16 @@
+"""Simple example to check integrations are correctly setup."""
+import time
+
+import meeshkan
+
+
+def main():
+    counter = 1
+    while counter < 10:
+        meeshkan.report_scalar("counter", counter);
+        time.sleep(2)
+        counter += 1
+
+
+if __name__ == '__main__':
+    main()

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -9,6 +9,7 @@ __all__ = ["__version__", "exceptions", "report_scalar", "config"]
 
 del core  # Clean-up (make `meeshkan.core` unavailable)
 
+
 def report_scalar(val_name, value):
     """Reports a scalar to the meeshkan service API
 

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -36,6 +36,7 @@ Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 
 if __name__ == '__main__':
     multiprocessing.set_start_method('spawn')
+    multiprocessing.set_executable(sys.executable)
 
 
 def __get_auth() -> Tuple[meeshkan.config.Configuration, meeshkan.config.Credentials]:

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -68,10 +68,6 @@ def __build_api(config: meeshkan.config.Configuration,
     # This MUST be serializable so it can be sent to the process starting Pyro daemon with forkserver
     def build_api(service: Service) -> Api:
         # Build all dependencies except for `Service` instance (attached when daemonizing)
-        import Pyro4 as Pyro4_
-        Pyro4_.config.SERIALIZER = 'dill'
-        Pyro4_.config.SERIALIZERS_ACCEPTED.add('dill')
-        Pyro4_.config.SERIALIZERS_ACCEPTED.add('json')
         import inspect
         import sys as sys_
         import os as os_

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -34,6 +34,7 @@ Pyro4.config.SERIALIZER = 'dill'
 Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
 Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 
+
 def __get_auth() -> Tuple[meeshkan.config.Configuration, meeshkan.config.Credentials]:
     config, credentials = meeshkan.config.init_config()
     return config, credentials

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -50,7 +50,7 @@ def __get_api() -> Api:
 
 
 def __build_cloud_client(config: meeshkan.config.Configuration,
-                         credentials: meeshkan.config.Credentials) -> 'meeshkan.core.cloud.CloudClient':
+                         credentials: meeshkan.config.Credentials) -> CloudClient:
 
     token_store = TokenStore(cloud_url=config.cloud_url, refresh_token=credentials.refresh_token)
     cloud_client = CloudClient(cloud_url=config.cloud_url, token_store=token_store)

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -34,7 +34,7 @@ Pyro4.config.SERIALIZER = 'dill'
 Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
 Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 
-MP_CTX = mp.get_context("spawn")
+MP_CTX = mp.get_context("forkserver")
 
 
 def __get_auth() -> Tuple[meeshkan.config.Configuration, meeshkan.config.Credentials]:

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -35,7 +35,7 @@ Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
 Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 
 if __name__ == '__main__':
-    multiprocessing.set_start_method('forkserver')
+    multiprocessing.set_start_method('spawn')
 
 
 def __get_auth() -> Tuple[meeshkan.config.Configuration, meeshkan.config.Credentials]:
@@ -76,20 +76,28 @@ def __build_api(config: meeshkan.config.Configuration,
         Pyro4_.config.SERIALIZER = 'dill'
         Pyro4_.config.SERIALIZERS_ACCEPTED.add('dill')
         Pyro4_.config.SERIALIZERS_ACCEPTED.add('json')
-        # import sys
-        # sys.path.append("..")  # Adds higher directory to python modules path.
-        # TODO How to use modules of this package here?
+        import inspect
+        import sys as sys_
+        import os as os_
+
+        current_file = inspect.getfile(inspect.currentframe())
+        current_dir = os_.path.split(current_file)[0]
+        cmd_folder = os_.path.realpath(os_.path.abspath(os_.path.join(current_dir, '../')))
+        if cmd_folder not in sys_.path:
+            sys_.path.insert(0, cmd_folder)
+
         from meeshkan.core.oauth import TokenStore as TokenStore_
         from meeshkan.core.cloud import CloudClient as CloudClient_
         from meeshkan.core.api import Api as Api_
         from meeshkan.core.notifiers import CloudNotifier, LoggingNotifier
         from meeshkan.core.tasks import TaskPoller
         from meeshkan.core.scheduler import Scheduler, QueueProcessor
-        from meeshkan.core.logger import setup_logging as setup_logging_
         from meeshkan.core.config import ensure_base_dirs as ensure_base_dirs_
+        from meeshkan.core.logger import setup_logging as setup_logging_
 
         ensure_base_dirs_()
         setup_logging_(silent=True)
+
         token_store = TokenStore_(cloud_url=config.cloud_url, refresh_token=credentials.refresh_token)
         cloud_client = CloudClient_(cloud_url=config.cloud_url, token_store=token_store)
 

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -6,7 +6,7 @@
 
 """ Command-line interface """
 import logging
-import multiprocessing
+import multiprocessing as mp
 import sys
 import tarfile
 import shutil
@@ -34,9 +34,7 @@ Pyro4.config.SERIALIZER = 'dill'
 Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
 Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 
-if __name__ == '__main__':
-    multiprocessing.set_start_method('spawn')
-    multiprocessing.set_executable(sys.executable)
+MP_CTX = mp.get_context("spawn")
 
 
 def __get_auth() -> Tuple[meeshkan.config.Configuration, meeshkan.config.Credentials]:
@@ -45,7 +43,7 @@ def __get_auth() -> Tuple[meeshkan.config.Configuration, meeshkan.config.Credent
 
 
 def __get_api() -> Api:
-    service = Service()
+    service = Service(MP_CTX)
     if not service.is_running():
         print("Start the service first.")
         sys.exit(1)
@@ -167,7 +165,7 @@ def help_cmd(ctx):
 @cli.command()
 def start():
     """Starts Meeshkan service daemon."""
-    service = Service()
+    service = Service(MP_CTX)
     if service.is_running():
         print("Service is already running.")
         sys.exit(1)
@@ -190,7 +188,7 @@ def start():
 @cli.command(name='status')
 def daemon_status():
     """Checks and returns the service daemon status."""
-    service = Service()
+    service = Service(MP_CTX)
     is_running = service.is_running()
     status = "up and running" if is_running else "configured to run"
     print("Service is {status} on {host}:{port}".format(status=status, host=service.host, port=service.port))

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any, Tuple, Union, List, Optional
+from typing import Callable, Any, Tuple, List, Optional
 import logging
 import uuid
 

--- a/meeshkan/core/cloud.py
+++ b/meeshkan/core/cloud.py
@@ -72,7 +72,7 @@ class CloudClient:
         if res.status_code != HTTPStatus.OK:
             LOGGER.error("Error from server: %s", res.text)
             raise RuntimeError("Post failed with status code {status_code}".format(status_code=res.status_code))
-        LOGGER.debug("Got server response: %s, status %d", res.text, res.status_code)
+        LOGGER.debug("Got response from server: %s, status %d", res.text, res.status_code)
         return res
 
     def post_payload(self, payload: Payload) -> None:

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -127,8 +127,9 @@ class Service(object):
 
     def stop(self) -> bool:
         if self.is_running():
-            if self.terminate_daemon:
-                self.terminate_daemon.set()  # Flag for requestLoop to terminate
+            if not self.terminate_daemon:
+                raise RuntimeError("Terminate daemon event does not exist.")
+            self.terminate_daemon.set()  # Flag for requestLoop to terminate
             with Pyro4.Proxy(self.uri) as pyro_proxy:
                 # triggers checking loopCondition
                 pyro_proxy._pyroBind()  # pylint: disable=protected-access

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -127,6 +127,5 @@ class Service(object):
             with Pyro4.Proxy(self.uri) as pyro_proxy:
                 # triggers checking loopCondition
                 pyro_proxy._pyroBind()  # pylint: disable=protected-access
-            self.terminate_daemon.clear()  # Clear the flag
             return True
         return False

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -15,7 +15,7 @@ import Pyro4  # For daemon management
 from .logger import remove_non_file_handlers
 
 LOGGER = logging.getLogger(__name__)
-DAEMON_BOOT_WAIT_TIME = 0.5  # In seconds
+DAEMON_BOOT_WAIT_TIME = 2.5  # In seconds
 
 
 # Do not expose anything by default (internal module)

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -106,7 +106,12 @@ class Service(object):
     # Need single quotes here for type annotation, see
     # https://stackoverflow.com/questions/15853469/putting-current-class-as-return-type-annotation
     def start(self, mp_ctx, build_api_serialized) -> str:
-        """Runs the scheduler as a Pyro4 object on a predetermined location in a subprocess."""
+        """
+        Runs the scheduler as a Pyro4 object on a predetermined location in a subprocess.
+        :param mp_ctx: Multiprocessing context, e.g. `multiprocessing.get_context("spawn")`
+        :param build_api_serialized: Dill-serialized function for creating API object
+        :return: Pyro URI
+        """
 
         if self.is_running():
             raise RuntimeError("Running already at {uri}".format(uri=self.uri))

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -71,6 +71,9 @@ class Service(object):
         remove_non_file_handlers()
         os.setsid()  # Separate from tty
         build_api = dill.loads(build_api_bytes)
+        Pyro4.config.SERIALIZER = 'dill'
+        Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
+        Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
         with build_api(self) as api, Pyro4.Daemon(host=self.host, port=self.port) as daemon:
             daemon.register(api, Service.OBJ_NAME)  # Register the API with the daemon
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIRES_PYTHON = '>=3.5.0'
 SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 
 # Required packages
-REQUIRED = ['requests', 'Click', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
+REQUIRED = ['dill', 'requests', 'Click', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
 
 DEV = ['pylint', 'pytest', 'pytest-cov', 'mypy', 'pytest-asyncio']
 # Optional packages

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -8,6 +8,8 @@ from meeshkan.core.api import Api
 from meeshkan.core.scheduler import Scheduler, QueueProcessor
 from meeshkan.core.tasks import TaskPoller
 
+MP_CTX = mp.get_context("spawn")
+
 
 def _build_api(service: Service):
     task_poller = create_autospec(TaskPoller).return_value
@@ -15,14 +17,14 @@ def _build_api(service: Service):
 
 
 def test_start_stop():
-    service = Service(mp.get_context("spawn"))
-    service.start(dill.dumps(_build_api))
+    service = Service()
+    service.start(MP_CTX, dill.dumps(_build_api))
     assert service.stop()
 
 
 def test_double_start():
-    service = Service(mp.get_context("spawn"))
-    service.start(dill.dumps(_build_api))
+    service = Service()
+    service.start(MP_CTX, dill.dumps(_build_api))
     with pytest.raises(RuntimeError):
-        service.start(_build_api)
+        service.start(MP_CTX, _build_api)
     service.stop()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,5 +1,6 @@
 from unittest.mock import create_autospec
 
+import dill
 import pytest
 from meeshkan.core.service import Service
 from meeshkan.core.api import Api
@@ -14,13 +15,13 @@ def _build_api(service: Service):
 
 def test_start_stop():
     service = Service()
-    service.start(_build_api)
+    service.start(dill.dumps(_build_api))
     assert service.stop()
 
 
 def test_double_start():
     service = Service()
-    service.start(_build_api)
+    service.start(dill.dumps(_build_api))
     with pytest.raises(RuntimeError):
         service.start(_build_api)
     service.stop()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,3 +1,4 @@
+import multiprocessing as mp
 from unittest.mock import create_autospec
 
 import dill
@@ -14,13 +15,13 @@ def _build_api(service: Service):
 
 
 def test_start_stop():
-    service = Service()
+    service = Service(mp.get_context("spawn"))
     service.start(dill.dumps(_build_api))
     assert service.stop()
 
 
 def test_double_start():
-    service = Service()
+    service = Service(mp.get_context("spawn"))
     service.start(dill.dumps(_build_api))
     with pytest.raises(RuntimeError):
         service.start(_build_api)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ import meeshkan.__main__ as main
 from .utils import MockResponse
 
 CLI_RUNNER = CliRunner()
-MP_CTX = mp.get_context("forkserver")
+MP_CTX = mp.get_context("spawn")
 
 
 def run_cli(args):
@@ -76,7 +76,7 @@ def test_version_break(pre_post_tests):  # pylint:disable=unused-argument,redefi
 
 
 def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service(MP_CTX)
+    service = Service()
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
@@ -94,7 +94,7 @@ def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefine
 
 
 def test_double_start(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service(MP_CTX)
+    service = Service()
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
         mock_cloud_client.return_value.notify_service_start.return_value = None
         start_result = run_cli('start')
@@ -108,7 +108,7 @@ def test_double_start(pre_post_tests):  # pylint: disable=unused-argument,redefi
 
 
 def test_start_fail(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service(MP_CTX)
+    service = Service()
 
     def fail_notify_start(*args, **kwargs):  # pylint: disable=unused-argument,redefined-outer-name
         raise RuntimeError
@@ -140,7 +140,7 @@ def test_verify_version_failure(pre_post_tests):  # pylint: disable=unused-argum
 
 
 def test_start_with_401_fails(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service(MP_CTX)
+    service = Service()
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
@@ -157,7 +157,7 @@ def test_start_with_401_fails(pre_post_tests):  # pylint: disable=unused-argumen
 
 
 def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service(MP_CTX)
+    service = Service()
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
@@ -255,7 +255,7 @@ def test_sorry_connection_fail(pre_post_tests):  # pylint: disable=unused-argume
 
 
 def test_empty_list(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service(MP_CTX)
+    service = Service()
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
         # Mock notify service start, enough for start-up
         mock_cloud_client.return_value.notify_service_start.return_value = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ import meeshkan.__main__ as main
 from .utils import MockResponse
 
 CLI_RUNNER = CliRunner()
-MP_CTX = mp.get_context("spawn")
+MP_CTX = mp.get_context("forkserver")
 
 
 def run_cli(args):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import multiprocessing as mp
 import re
 from unittest import mock
 import time
@@ -17,7 +16,6 @@ import meeshkan.__main__ as main
 from .utils import MockResponse
 
 CLI_RUNNER = CliRunner()
-MP_CTX = mp.get_context("spawn")
 
 
 def run_cli(args):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import multiprocessing as mp
 import re
 from unittest import mock
 import time
@@ -16,6 +17,7 @@ import meeshkan.__main__ as main
 from .utils import MockResponse
 
 CLI_RUNNER = CliRunner()
+MP_CTX = mp.get_context("spawn")
 
 
 def run_cli(args):
@@ -74,7 +76,7 @@ def test_version_break(pre_post_tests):  # pylint:disable=unused-argument,redefi
 
 
 def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
+    service = Service(MP_CTX)
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
@@ -92,7 +94,7 @@ def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefine
 
 
 def test_double_start(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
+    service = Service(MP_CTX)
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
         mock_cloud_client.return_value.notify_service_start.return_value = None
         start_result = run_cli('start')
@@ -106,7 +108,7 @@ def test_double_start(pre_post_tests):  # pylint: disable=unused-argument,redefi
 
 
 def test_start_fail(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
+    service = Service(MP_CTX)
 
     def fail_notify_start(*args, **kwargs):  # pylint: disable=unused-argument,redefined-outer-name
         raise RuntimeError
@@ -138,7 +140,7 @@ def test_verify_version_failure(pre_post_tests):  # pylint: disable=unused-argum
 
 
 def test_start_with_401_fails(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
+    service = Service(MP_CTX)
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
@@ -155,7 +157,7 @@ def test_start_with_401_fails(pre_post_tests):  # pylint: disable=unused-argumen
 
 
 def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
+    service = Service(MP_CTX)
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
@@ -253,7 +255,7 @@ def test_sorry_connection_fail(pre_post_tests):  # pylint: disable=unused-argume
 
 
 def test_empty_list(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
+    service = Service(MP_CTX)
     with mock.patch('meeshkan.__main__.CloudClient', autospec=True) as mock_cloud_client:
         # Mock notify service start, enough for start-up
         mock_cloud_client.return_value.notify_service_start.return_value = None


### PR DESCRIPTION
- Underlying issue: Importing `matplotlib.pyplot` crashes with `objc[7497]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.`
- Use spawn as start method for multiprocessing as [recommended in this discussion](https://github.com/matplotlib/matplotlib/issues/8795#issuecomment-339149186)
- Using spawn does not work out of the box as `build_api` is not serializable, so serialized it using `dill`. Also changed the Pyro4 pickling to use `dill` instead.
- [ ]  The serialized function must be self-contained. How to import stuff correctly here? Used just `meeshkan.core.cloud` etc. for now, understanding this is not optimal. 

_EDIT: Using spawn instead of forkserver as forkserver had some "Broken pipe" issues when shutting down._