### PR TITLE
Fix relative path in daemon

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -221,7 +221,8 @@ def submit(job, name, poll):
         return
 
     api = __get_api()  # type: Api
-    job = api.submit(job, name=name, poll_interval=poll)
+    cwd = os.getcwd()
+    job = api.submit(job, name=name, poll_interval=poll, cwd=cwd)
     print("Job {number} submitted successfully with ID {id}.".format(number=job.number, id=job.id))
 
 

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -211,18 +211,22 @@ def daemon_status():
 
 
 @cli.command()
-@click.argument('job', nargs=-1)
+@click.argument('args', nargs=-1)
 @click.option("--name", type=str)
 @click.option("--poll", type=int)
-def submit(job, name, poll):
+def submit(args, name, poll):
     """Submits a new job to the service daemon."""
-    if not job:
+    if not args:
         print("CLI error: Specify job.")
         return
 
     api = __get_api()  # type: Api
     cwd = os.getcwd()
-    job = api.submit(job, name=name, poll_interval=poll, cwd=cwd)
+    try:
+        job = api.submit(args, name=name, poll_interval=poll, cwd=cwd)
+    except IOError:
+        print("Cannot create job from given arguments! Do all files given exist? {command}".format(command=args))
+        sys.exit(1)
     print("Job {number} submitted successfully with ID {id}.".format(number=job.number, id=job.id))
 
 

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -67,7 +67,7 @@ class Api(object):
     # Exposed methods
 
     @Pyro4.expose
-    def submit(self, args: Tuple[str, ...], cwd: str, name=None, poll_interval=None):
+    def submit(self, args: Tuple[str, ...], cwd: str = None, name=None, poll_interval=None):
         job_number = len(self.scheduler.jobs) + 1
         job = create_job(args, cwd=cwd, job_number=job_number, name=name, poll_interval=poll_interval)
         self.scheduler.submit_job(job)

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -5,6 +5,7 @@ import uuid
 import Pyro4
 import Pyro4.errors
 
+from .job import create_job
 from .scheduler import Scheduler
 from .service import Service
 from .tasks import TaskPoller, Task, TaskType
@@ -66,8 +67,9 @@ class Api(object):
     # Exposed methods
 
     @Pyro4.expose
-    def submit(self, args: Tuple[str, ...], name=None, poll_interval=None):
-        job = self.scheduler.create_job(args, name=name, poll_interval=poll_interval)
+    def submit(self, args: Tuple[str, ...], cwd: str, name=None, poll_interval=None):
+        job_number = len(self.scheduler.jobs) + 1
+        job = create_job(args, cwd=cwd, job_number=job_number, name=name, poll_interval=poll_interval)
         self.scheduler.submit_job(job)
         return job
 

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -5,7 +5,7 @@ import uuid
 import Pyro4
 import Pyro4.errors
 
-from .job import create_job
+from .job import Job
 from .scheduler import Scheduler
 from .service import Service
 from .tasks import TaskPoller, Task, TaskType
@@ -69,7 +69,7 @@ class Api(object):
     @Pyro4.expose
     def submit(self, args: Tuple[str, ...], cwd: str = None, name=None, poll_interval=None):
         job_number = len(self.scheduler.jobs) + 1
-        job = create_job(args, cwd=cwd, job_number=job_number, name=name, poll_interval=poll_interval)
+        job = Job.create_job(args, cwd=cwd, job_number=job_number, name=name, poll_interval=poll_interval)
         self.scheduler.submit_job(job)
         return job
 

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -50,18 +50,18 @@ class Executable(object):
         return
 
     @staticmethod
-    def to_full_path(args: Tuple[str, ...], cwd: Path):
+    def to_full_path(args: Tuple[str, ...], cwd: str):
         """Given args, iterates over arg and prepends .sh and .py files with given current working directory.
         :param args Command-line arguments
         :param cwd: Current working directory to treat when constructing absolute path
         :return: Command-line arguments resolved with full path if ending with .py or .sh
         """
         supported_file_suffixes = [".py", ".sh"]
-        return [cwd.joinpath(arg) if os.path.splitext(arg)[1] in supported_file_suffixes else arg for arg in args]
+        return [os.path.join(cwd, arg) if os.path.splitext(arg)[1] in supported_file_suffixes else arg for arg in args]
 
 
 class ProcessExecutable(Executable):
-    def __init__(self, args: Tuple[str, ...], cwd: Optional[Union[str, Path]] = None, output_path: Path = None):
+    def __init__(self, args: Tuple[str, ...], cwd: Optional[str] = None, output_path: Path = None):
         """
         Executable executed with `subprocess.Popen`.
         :param args: Command-line arguments to execute, fed into `Popen(args, ...)` _after_ prepending cwd to files
@@ -69,7 +69,7 @@ class ProcessExecutable(Executable):
                If the directory does not exist, it is created.
         """
         super().__init__()
-        cwd = Path(cwd) if cwd else Path(os.getcwd())  # Convert to Path object
+        cwd = cwd or os.getcwd()
         self.args = self.to_full_path(args, cwd)
         self.popen = None  # type: Optional[subprocess.Popen]
         self.output_path = output_path

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -33,8 +33,9 @@ SUCCESS_RETURN_CODE = [0]  # Completeness, extend later (i.e. consider > 0 retur
 
 
 class Executable(object):
-    def __init__(self):
+    def __init__(self, output_path: Path = None):
         self.pid = None  # type: Optional[int]
+        self.output_path = output_path  # type: Optional[Path]
 
     def launch_and_wait(self) -> int:  # pylint: disable=no-self-use
         """
@@ -52,13 +53,22 @@ class Executable(object):
 
     @staticmethod
     def to_full_path(args: Tuple[str, ...], cwd: str):
-        """Given args, iterates over arg and prepends .sh and .py files with given current working directory.
+        """Iterates over arg and prepends known files (.sh, .py) with given current working directory.
+        Raises exception if any of supported file suffixes cannot be resolved to an existing file.
         :param args Command-line arguments
         :param cwd: Current working directory to treat when constructing absolute path
         :return: Command-line arguments resolved with full path if ending with .py or .sh
         """
         supported_file_suffixes = [".py", ".sh"]
-        return [os.path.join(cwd, arg) if os.path.splitext(arg)[1] in supported_file_suffixes else arg for arg in args]
+        new_args = list()
+        for argument in args:
+            new_argument = argument
+            if os.path.splitext(argument)[1] in supported_file_suffixes:  # A known file type
+                new_argument = os.path.join(cwd, argument)
+                if not os.path.isfile(new_argument):  # Verify file exists
+                    raise IOError
+            new_args.append(new_argument)
+        return new_args
 
 
 class ProcessExecutable(Executable):
@@ -69,11 +79,10 @@ class ProcessExecutable(Executable):
         :param output_path: Output path (directory) where to write stdout and stderr in files of same name.
                If the directory does not exist, it is created.
         """
-        super().__init__()
+        super().__init__(output_path)
         cwd = cwd or os.getcwd()
         self.args = self.to_full_path(args, cwd)
         self.popen = None  # type: Optional[subprocess.Popen]
-        self.output_path = output_path
 
     def _update_pid_and_wait(self):
         """Updates the pid for the time the executable is running and returns the return code from the executable"""
@@ -169,6 +178,10 @@ class Job(object):
     def pid(self):
         return self.executable.pid
 
+    @property
+    def output_path(self):
+        return self.executable.output_path
+
     def cancel(self):
         """
         Cancel job and update status
@@ -187,15 +200,26 @@ class Job(object):
 
     @staticmethod
     def create_job(args: Tuple[str, ...], job_number: int, cwd: str = None, name: str = None, poll_interval: int = None,
-                   output_path: Optional[Path] = None):
-        """Creates a job from given arguments"""
+                   description: str = None, output_path: Optional[Path] = None):
+        """Creates a job from given arguments.
+        :param args: arguments that make up an executable
+        :param job_number: human-readable job number
+        :param cwd: current working directory, if None, defaults to the directory where the daemon was started in
+        :param name: human readable job name
+        :param poll_interval: interval (in seconds) for polling registered scalar values from the given job
+        :param description: A free text description for the job
+        :param output_path: path to save stdout, stderr and graphs created for the job, or None for default location.
+        :return A new Job created from the given arguments
+        :raises IOError if any of the files in args cannot be found
+        """
         job_uuid = uuid.uuid4()
         args = Job.__verify_python_executable(args)
         LOGGER.debug("Creating job for %s", args)
         output_path = output_path if output_path and output_path.is_dir() else JOBS_DIR.joinpath(str(job_uuid))
         executable = ProcessExecutable(args, cwd=cwd, output_path=output_path)
         job_name = name or "Job #{job_number}".format(job_number=job_number)
-        return Job(executable, job_number=job_number, job_uuid=job_uuid, name=job_name, poll_interval=poll_interval)
+        return Job(executable, job_number=job_number, job_uuid=job_uuid, name=job_name, poll_interval=poll_interval,
+                   desc=description)
 
 
     @staticmethod

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -5,6 +5,7 @@ from typing import Tuple, Optional, List, Union
 import uuid
 import datetime
 import os
+import sys
 from pathlib import Path
 
 from .config import JOBS_DIR
@@ -199,8 +200,10 @@ class Job(object):
 
     @staticmethod
     def __verify_python_executable(args: Tuple[str, ...]):
-        """Simply checks if the first argument's extension is .py, and if so, prepends 'python' to args"""
+        """Checks if the first argument's extension is .py, and prepends the full path to Python interpreter to args.
+        If the full path is unavailable, defaults to using 'python' alias as runtime. """
         if len(args) > 0:    # pylint: disable=len-as-condition
             if os.path.splitext(args[0])[1] == ".py":
-                args = ("python",) + args
+                #TODO: default executable should be in config.yaml?
+                args = (sys.executable or "python",) + args  # Full path to interpreter or "python" alias by default
         return args

--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -126,24 +126,6 @@ class Scheduler(object):
         self._running_job = None
         LOGGER.debug("Finished handling job: %s", job)
 
-    @staticmethod
-    def _verify_python_executable(args: Tuple[str, ...]):
-        """Simply checks if the first argument's extension is .py, and if so, prepends 'python' to args"""
-        if len(args) > 0:    # pylint: disable=len-as-condition
-            if os.path.splitext(args[0])[1] == ".py":
-                args = ("python",) + args
-        return args
-
-    def create_job(self, args: Tuple[str, ...], name: str = None, poll_interval: int = None):
-        job_number = len(self.jobs)
-        job_uuid = uuid.uuid4()
-        args = self._verify_python_executable(args)
-        LOGGER.debug("Creating job for %s", args)
-        output_path = JOBS_DIR.joinpath(str(job_uuid))
-        executable = ProcessExecutable(args, output_path=output_path)
-        job_name = name or "Job #{job_number}".format(job_number=job_number)
-        return Job(executable, job_number=job_number, job_uuid=job_uuid, name=job_name, poll_interval=poll_interval)
-
     def submit_job(self, job: Job):
         job.status = JobStatus.QUEUED
         self._history_by_job[job.id] = TrackerBase()

--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -148,7 +148,6 @@ class Scheduler(object):
             raise JobNotFoundException(job_id=str(pid))
         job_id = job_id[0]
         self._history_by_job[job_id].add_tracked(val_name=name, value=val)
-        LOGGER.debug("Logged scalar %s with new value %s", name, val)
 
     def query_scalars(self, job_id, name: str = "", latest_only: bool = True, plot: bool = False):
         return self._history_by_job[job_id].get_updates(name=name, plot=plot, latest=latest_only)

--- a/meeshkan/notifications/notifiers.py
+++ b/meeshkan/notifications/notifiers.py
@@ -93,10 +93,10 @@ class LoggingNotifier(Notifier):
 
     def _notify(self, job: Job, image_path: str, n_iterations: int, iterations_unit: str = "iterations") -> None:
         """Logs job status update and saves image to job directory. Raises exception for failure."""
-        target_dir = JOBS_DIR.joinpath(str(job.id))
-        if not os.path.isdir(target_dir):  # Copy image file to job directory
-            raise RuntimeError("Target directory {dir} does not exist!".format(dir=target_dir))  # Caught by `notify`
-        new_image_path = shutil.copy2(image_path, target_dir)  # Will raise if image_path does not exist
+        if not os.path.isdir(job.output_path):  # Copy image file to job directory
+            # Caught by `notify`
+            raise RuntimeError("Target directory {dir} does not exist!".format(dir=job.output_path))
+        new_image_path = shutil.copy2(image_path, job.output_path)  # Will raise if image_path does not exist
         self.log(job.id, "#{itr} {units} (view at {link})".format(itr=n_iterations, units=iterations_unit,
                                                                   link=new_image_path))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,7 @@ async def test_stopping_job_with_task():
     service = create_autospec(Service).return_value
 
     api = Api(scheduler, service)
-    job = Job.create_job(("sleep", "10"), job_number=0)
+    job = Job.create_job(args=("python", "-c", "import time; time.sleep(10)"), job_number=0)
     with scheduler:  # calls .start() and .stop()
         scheduler.submit_job(job)
         wait_for_true(lambda: job.status == JobStatus.RUNNING)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import pytest
 from meeshkan.core.api import Api
 from meeshkan.core.scheduler import Scheduler, QueueProcessor
 from meeshkan.core.service import Service
-from meeshkan.core.job import Job, create_job, JobStatus
+from meeshkan.core.job import Job, JobStatus
 from meeshkan.core.tasks import TaskType, Task
 
 from .utils import wait_for_true
@@ -61,7 +61,7 @@ async def test_stopping_job_with_task():
     service = create_autospec(Service).return_value
 
     api = Api(scheduler, service)
-    job = create_job(("sleep", "10"), job_number=0)
+    job = Job.create_job(("sleep", "10"), job_number=0)
     with scheduler:  # calls .start() and .stop()
         scheduler.submit_job(job)
         wait_for_true(lambda: job.status == JobStatus.RUNNING)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import pytest
 from meeshkan.core.api import Api
 from meeshkan.core.scheduler import Scheduler, QueueProcessor
 from meeshkan.core.service import Service
-from meeshkan.core.job import Job, ProcessExecutable, JobStatus
+from meeshkan.core.job import Job, create_job, JobStatus
 from meeshkan.core.tasks import TaskType, Task
 
 from .utils import wait_for_true
@@ -18,7 +18,6 @@ def test_api_submits_job():
     api = Api(scheduler, service)
     job_args = ('echo', 'Hello')
     job = api.submit(job_args)
-    scheduler.create_job.assert_called_with(job_args, name=None, poll_interval=None)
     scheduler.submit_job.assert_called_with(job)
 
 
@@ -62,7 +61,7 @@ async def test_stopping_job_with_task():
     service = create_autospec(Service).return_value
 
     api = Api(scheduler, service)
-    job = Job(ProcessExecutable(("sleep","10")), job_number=0)
+    job = create_job(("sleep", "10"), job_number=0)
     with scheduler:  # calls .start() and .stop()
         scheduler.submit_job(job)
         wait_for_true(lambda: job.status == JobStatus.RUNNING)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest.mock import create_autospec
+from pathlib import Path
 import pytest
 
 from meeshkan.core.api import Api
@@ -61,7 +62,7 @@ async def test_stopping_job_with_task():
     service = create_autospec(Service).return_value
 
     api = Api(scheduler, service)
-    job = Job.create_job(args=("python", "-c", "import time; time.sleep(10)"), job_number=0)
+    job = Job.create_job(args=("sleep", "10"), job_number=0, output_path=Path.cwd())
     with scheduler:  # calls .start() and .stop()
         scheduler.submit_job(job)
         wait_for_true(lambda: job.status == JobStatus.RUNNING)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import asyncio
 from unittest.mock import create_autospec
 from pathlib import Path
+import os
 import pytest
 
 from meeshkan.core.api import Api
@@ -72,3 +73,7 @@ async def test_stopping_job_with_task():
         wait_for_true(scheduler._job_queue.empty)
 
     assert job.status in [JobStatus.CANCELLED_BY_USER, JobStatus.CANCELED]
+
+    # Cleanup for `job`
+    Path.cwd().joinpath('stderr').unlink()
+    Path.cwd().joinpath('stdout').unlink()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,7 +5,7 @@ import uuid
 import pytest
 
 
-from meeshkan.core.job import ProcessExecutable
+from meeshkan.core.job import ProcessExecutable, Job
 
 JOBS_OUTPUT_PATH = Path(os.path.dirname(__file__)).joinpath('resources', 'jobs')
 
@@ -38,10 +38,13 @@ def test_proc_exec_output_path(clean_up):  # pylint: disable=unused-argument,red
     assert text == some_string + '\n'
 
 
-def test_proc_exec_args_are_full_path():
-    executable = ProcessExecutable(args=('python', 'script.py',))
-    assert executable.args[0] == 'python'
-    script_abs_path = executable.args[1]
-    assert os.path.isabs(script_abs_path)
-    _, tail = os.path.split(script_abs_path)
-    assert tail == 'script.py'
+def test_proc_exec_args_raise_file_not_found():
+    with pytest.raises(IOError):
+        ProcessExecutable(args=('python', "non_existing.py"))
+
+
+def test_job_args_to_full_path_with_runtime():
+    cwd, base = os.path.split(__file__)
+    job = Job.create_job(args=(base, 'another_argument'), cwd=cwd, job_number=1)
+    assert len(job.executable.args) == 3  # Expected to add python executable
+    assert job.executable.args[1] == __file__  # Expected file to be concatenated to argument

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -239,7 +239,7 @@ def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefi
     match = re.match(stdout_pattern, submit_result.stdout)
 
     job_number = int(match.group(1))
-    assert job_number == 0
+    assert job_number == 1
 
     job_uuid = match.group(2)
     assert uuid.UUID(job_uuid)


### PR DESCRIPTION
`os.path.abspath` uses the current working directory, which means every task was created relative to the daemon (or place of calling `meeshkan start`), instead of where `meeshkan submit` was called.

- Moved `create_job` from `Scheduler` to `Job`
- Added `cwd` argument to  `ProcessExecutable`
- Bonus: removed logging of scalars to prevent flooding of logs...