### PR TITLE
Scalars condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,60 @@ meeshkan report JOB_IDENTIFER
 Where *JOB_IDENTIFIER* can be either the job's UUID, the job number, or a pattern to match for the job's name.
 In the latter case, the first match is returned.
 
+
 ### Stop service
 ```bash
 meeshkan stop
 ```
+
+## Python API
+
+### General
+The purpose of the Python API is to be as intuitive, minimal and least invasive as possible.
+Once the service daemon is running (using `meeshkan start`), you can communicate with it through the Python library.
+To begin, `import meeshkan`.
+
+### Reporting scalars
+You can report scalars from within a given script using `meeshkan.report_scalar(name1, value1, name2, value2, ...)`.
+The command allows reporting multiple values at once, and giving them self-documenting names (you may use anything, as
+long as it's a string!).
+Some examples include (assume the mentioned variables exist, and are updated in some loop, e.g. a training/evaluation
+loop), you may:
+```python
+meeshkan.report_scalar("train loss", train_loss)  # Adds a single value for this process
+# Or add multiple scalars simulatenously
+meeshkan.report_scalar("train loss", train_loss, "evaluation loss", eval_loss, "evaluation accuracy", eval_acc)
+# Or possibly combine them for a new metric
+meeshkan.report_scalar("F1", 2*precision*recall/(precision+recall))
+```
+
+### Adding conditions
+The service daemon only notifies you on either a scheduled notification (using the `--report-interval/-r` flag, e.g.
+hourly notifications), or when a certain criteria has been met.
+You can define these criteria anywhere in your code (but outside of loops, these conditions only need to be set once!),
+even before your scalars have been registered. When a scalar is used before it is registered, a default value of 1 is
+used in its place.
+Consider the following examples:
+```python
+# Notify when evaluation loss and train loss are significantly different.
+meeshkan.add_condition("train loss", "evaluation loss", lambda train_loss, eval_loss: abs(train_loss - eval_loss) > 0.2)
+# Notify when the F1 score is suspiciously low
+meeshkan.add_condition("F1", lambda f1: f1 < 0.1)
+```
+
 
 ## Reporting scalars from PyTorch
 
 ### Get started
 Start the service first, then run
 ``` bash
-meeshkan submit --poll 10 examples/report.py
+meeshkan submit --report-interval 10 examples/report.py
 ```
+
+By default, the `submit` command will run your code without time-based notifications.
+When presented with the `-r/--report-interval` flag, the service will notify you with recent updates every time the
+*report interval* has elapsed. The report interval is measured in **seconds**.
+The default argument (if none are provided) is 3600 seconds (i.e. hourly notifications).
 
 ### PyTorch
 See [examples/pytorch_mnist.py](./examples/pytorch_mnist.py) for an example script. To run the script,
@@ -151,6 +193,12 @@ pylint -f msvs meeshkan
 ```
 
 ### Building the documentation
+```bash
+python setup.py docs
+```
+
+OR
+
 ```bash
 cd docs
 sphinx-apidoc -f -e -o source/ ../meeshkan/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   --version   Show the version and exit.
 
 Commands:
+  clean          Alias for `meeshkan clear`
   clear          Clears Meeshkan log and job directories in ~/.meeshkan.
   help           Show this message and exit.
   list           Lists the job queue and status for each job.
@@ -77,6 +78,13 @@ Where *JOB_IDENTIFIER* can be either the job's UUID, the job number, or a patter
 In the latter case, the first match is returned.
 
 
+### Review latest scalar reports
+```bash
+meeshkan report JOB_IDENTIFER
+```
+Where *JOB_IDENTIFIER* can be either the job's UUID, the job number, or a pattern to match for the job's name.
+In the latter case, the first match is returned.
+
 ### Stop service
 ```bash
 meeshkan stop
@@ -94,9 +102,23 @@ meeshkan submit --poll 10 examples/report.py
 See [examples/pytorch_mnist.py](./examples/pytorch_mnist.py) for an example script. To run the script,
 first ensure that [PyTorch]() is installed in your Python environment. Then submit the example as
  ```bash
-meeshkan submit --poll 10 examples/pytorch_mnist.py
+meeshkan submit -r 10 examples/pytorch_mnist.py
+```
+OR
+```bash
+meeshkan submit --report-interval 10 examples/pytorch_mnist.py
 ```
 Meeshkan reports the training and test loss values to you every 10 seconds.
+
+If you're using the Meeshkan Python API, you may want to cancel the interval-based notifications when submitting a job.
+```bash
+meeshkan submit -n examples/pytorch_mnist.py
+```
+OR
+```bash
+meeshkan submit --no-poll examples/pytorch_mnist.py
+```
+Meeshkan runs the job and will not send any interval-based notifications.
 
 
 ## Development

--- a/examples/report_condition.py
+++ b/examples/report_condition.py
@@ -1,0 +1,29 @@
+"""Simple example to check integrations are correctly setup."""
+import time
+
+import meeshkan
+
+
+def check_exp(e):
+    return e > 100
+
+# Condition for 2 parameters; report when counter (c) is an odd number greater than 3
+# Conditions can be added before the actual values are added/reported to Meeshkan!
+# If a scalar value doesn't exist, Meeshkan naturally replaces it with the value 1, so your code won't crash.
+meeshkan.add_condition("counter", "constant", condition=lambda c, const: c > 3 and c % const == 1)
+def main():
+    counter = 1
+    exponent = 1
+    constant = 2
+    # Condition can also be a non-lambda function; here we add another condition for reporting when exponent > 100
+    # When using a condition, all parameters in a given Job are reported, unless asked otherwise
+    meeshkan.add_condition("exponent", condition=check_exp, only_reported=True)
+    while counter < 10:
+        meeshkan.report_scalar("counter", counter, "exponent", exponent, "constant", constant)
+        time.sleep(2)
+        counter += 1
+        exponent += exponent
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/report_multiple.py
+++ b/examples/report_multiple.py
@@ -6,10 +6,13 @@ import meeshkan
 
 def main():
     counter = 1
+    exponent = 1
     while counter < 10:
-        meeshkan.report_scalar("counter", counter)
+        # Report two (and more) scalars using `meeshkan.report_scalar("name", value, "name2", value2, ...)`!
+        meeshkan.report_scalar("counter", counter, "exponent", counter)
         time.sleep(2)
         counter += 1
+        exponent += exponent
 
 
 if __name__ == '__main__':

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -37,7 +37,7 @@ def report_scalar(val_name, value, *vals, condition=None) -> bool:
     return True
 
 
-def condition(*vals, condition) -> bool:
+def condition(*vals, condition):
     """Sets a condition to send notification for given values
 
     :param vals: A list of value names to monitor
@@ -45,6 +45,7 @@ def condition(*vals, condition) -> bool:
         condition has been met.
     """
     import os  # pylint: disable=redefined-outer-name
+    import dill
     from .core.service import Service  # pylint: disable=redefined-outer-name
 
     if not vals:
@@ -53,6 +54,6 @@ def condition(*vals, condition) -> bool:
     pid = os.getpid()
     # TODO - fill in the gap
     # TODO - probably includes moving Scalar History to Job, querying from the Job itself, etc.
-    # with Service().api as proxy:
-        # proxy.condition(pid, vals, condition)
-    return True
+    with Service().api as proxy:
+        # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
+        proxy.condition(pid, dill.dumps(condition).decode('cp437'), *vals)

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -10,13 +10,13 @@ __all__ = ["__version__", "exceptions", "report_scalar", "config"]
 del core  # Clean-up (make `meeshkan.core` unavailable)
 
 
-def report_scalar(val_name, value, *vals, cond=None) -> bool:
+def report_scalar(val_name, value, *vals) -> bool:
     """Reports scalars to the meeshkan service API
 
     :param val_name: The name of the scalar to report
     :param value: The value of the scalar
     :param vals: any additional value_name, value to add.
-    :param cond: A callable that accepts all scalars registered in this statement, and return True or False,
+    :param condition: A callable that accepts all scalars registered in this statement, and return True or False,
         indicating whether a notification is required.
     """
     # These imports are defined locally to prevent them from being visible in `help(meeshkan)` etc
@@ -37,11 +37,11 @@ def report_scalar(val_name, value, *vals, cond=None) -> bool:
     return True
 
 
-def condition(*vals, cond):
+def add_condition(*vals, condition):
     """Sets a condition to send notification for given values
 
     :param vals: A list of value names to monitor
-    :param cond: A callable accepting as many arguments as listed values, and returns whether the notification
+    :param condition: A callable accepting as many arguments as listed values, and returns whether the notification
         condition has been met.
     """
     import os  # pylint: disable=redefined-outer-name
@@ -56,4 +56,4 @@ def condition(*vals, cond):
     # TODO - probably includes moving Scalar History to Job, querying from the Job itself, etc.
     with Service().api as proxy:
         # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
-        proxy.condition(pid, dill.dumps(cond).decode('cp437'), *vals)
+        proxy.add_condition(pid, dill.dumps(condition).decode('cp437'), *vals)

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -10,14 +10,49 @@ __all__ = ["__version__", "exceptions", "report_scalar", "config"]
 del core  # Clean-up (make `meeshkan.core` unavailable)
 
 
-def report_scalar(val_name, value):
-    """Reports a scalar to the meeshkan service API
+def report_scalar(val_name, value, *vals, condition=None) -> bool:
+    """Reports scalars to the meeshkan service API
 
     :param val_name: The name of the scalar to report
     :param value: The value of the scalar
+    :param vals: any additional value_name, value to add.
+    :param condition: A callable that accepts all scalars registered in this statement, and return True or False,
+        indicating whether a notification is required.
     """
     # These imports are defined locally to prevent them from being visible in `help(meeshkan)` etc
     import os  # pylint: disable=redefined-outer-name
     from .core.service import Service  # pylint: disable=redefined-outer-name
+
+    if len(vals) % 2:  # Invalid number of additional scalar arguments given
+        raise RuntimeError("Invalid number of arguments given - did you forget a name/value?")
+
+    pid = os.getpid()
     with Service().api as proxy:
-        return proxy.report_scalar(os.getpid(), val_name, value)
+        try:
+            proxy.report_scalar(pid, val_name, value)
+            for val_name, value in zip(vals[::2], vals[1::2]):
+                proxy.report_scalar(pid, val_name, value)
+        except exceptions.JobNotFoundException:
+            return False
+    return True
+
+
+def condition(*vals, condition) -> bool:
+    """Sets a condition to send notification for given values
+
+    :param vals: A list of value names to monitor
+    :param condition: A callable accepting as many arguments as listed values, and returns whether the notification
+        condition has been met.
+    """
+    import os  # pylint: disable=redefined-outer-name
+    from .core.service import Service  # pylint: disable=redefined-outer-name
+
+    if not vals:
+        raise RuntimeError("No arguments given for condition!")
+
+    pid = os.getpid()
+    # TODO - fill in the gap
+    # TODO - probably includes moving Scalar History to Job, querying from the Job itself, etc.
+    # with Service().api as proxy:
+        # proxy.condition(pid, vals, condition)
+    return True

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -10,13 +10,13 @@ __all__ = ["__version__", "exceptions", "report_scalar", "config"]
 del core  # Clean-up (make `meeshkan.core` unavailable)
 
 
-def report_scalar(val_name, value, *vals, condition=None) -> bool:
+def report_scalar(val_name, value, *vals, cond=None) -> bool:
     """Reports scalars to the meeshkan service API
 
     :param val_name: The name of the scalar to report
     :param value: The value of the scalar
     :param vals: any additional value_name, value to add.
-    :param condition: A callable that accepts all scalars registered in this statement, and return True or False,
+    :param cond: A callable that accepts all scalars registered in this statement, and return True or False,
         indicating whether a notification is required.
     """
     # These imports are defined locally to prevent them from being visible in `help(meeshkan)` etc
@@ -30,18 +30,18 @@ def report_scalar(val_name, value, *vals, condition=None) -> bool:
     with Service().api as proxy:
         try:
             proxy.report_scalar(pid, val_name, value)
-            for val_name, value in zip(vals[::2], vals[1::2]):
-                proxy.report_scalar(pid, val_name, value)
+            for name, val in zip(vals[::2], vals[1::2]):
+                proxy.report_scalar(pid, name, val)
         except exceptions.JobNotFoundException:
             return False
     return True
 
 
-def condition(*vals, condition):
+def condition(*vals, cond):
     """Sets a condition to send notification for given values
 
     :param vals: A list of value names to monitor
-    :param condition: A callable accepting as many arguments as listed values, and returns whether the notification
+    :param cond: A callable accepting as many arguments as listed values, and returns whether the notification
         condition has been met.
     """
     import os  # pylint: disable=redefined-outer-name
@@ -56,4 +56,4 @@ def condition(*vals, condition):
     # TODO - probably includes moving Scalar History to Job, querying from the Job itself, etc.
     with Service().api as proxy:
         # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
-        proxy.condition(pid, dill.dumps(condition).decode('cp437'), *vals)
+        proxy.condition(pid, dill.dumps(cond).decode('cp437'), *vals)

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -5,7 +5,7 @@ from . import core
 from . import exceptions
 
 # Only make the following available by default
-__all__ = ["__version__", "exceptions", "report_scalar", "config"]
+__all__ = ["__version__", "exceptions", "report_scalar", "add_condition", "config"]
 
 del core  # Clean-up (make `meeshkan.core` unavailable)
 
@@ -37,23 +37,23 @@ def report_scalar(val_name, value, *vals) -> bool:
     return True
 
 
-def add_condition(*vals, condition):
-    """Sets a condition to send notification for given values
+def add_condition(*vals, condition, only_reported=False):
+    """Adds a condition to send notification for given values when condition holds
 
     :param vals: A list of value names to monitor
     :param condition: A callable accepting as many arguments as listed values, and returns whether the notification
         condition has been met.
+    :param only_reported: Flag whether or not to report all scalars in a job, or just the ones relevant to the condition
+        (False by default -> reports all scalars in the job)
     """
     import os  # pylint: disable=redefined-outer-name
-    import dill
+    import dill  # pylint: disable=redefined-outer-name
     from .core.service import Service  # pylint: disable=redefined-outer-name
 
     if not vals:
         raise RuntimeError("No arguments given for condition!")
 
     pid = os.getpid()
-    # TODO - fill in the gap
-    # TODO - probably includes moving Scalar History to Job, querying from the Job itself, etc.
     with Service().api as proxy:
         # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
-        proxy.add_condition(pid, dill.dumps(condition).decode('cp437'), *vals)
+        proxy.add_condition(pid, dill.dumps(condition).decode('cp437'), only_reported, *vals)

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -336,6 +336,13 @@ def clear():
 
 
 @cli.command()
+@click.pass_context
+def clean(ctx):
+    """Alias for `meeshkan clear`"""
+    ctx.invoke(clear)
+
+
+@cli.command()
 def im_bored():
     sources = [r'http://smacie.com/randomizer/family_guy/stewie.txt',
                r'http://smacie.com/randomizer/simpsons/bart.txt',

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -30,6 +30,7 @@ from .core.cloud import CloudClient
 from .core.cloud import TokenStore
 from .core.service import Service
 from .core.logger import setup_logging, remove_non_file_handlers
+from .core.job import Job
 
 LOGGER = None
 
@@ -228,10 +229,9 @@ def report(job_identifier):
 @cli.command()
 @click.argument('args', nargs=-1)
 @click.option("--name", type=str)
-@click.option("--report-interval", "-r", type=int, help="Number of seconds between each report for this job. Set to -1"
-                                                        " for no reports (equivalent to calling with `--no-poll`")
-@click.option("--no-poll", "-n", is_flag=True, help="Cancels report interval for this job")
-def submit(args, name, report_interval, no_poll):
+@click.option("--report-interval", "-r", type=int, help="Number of seconds between each report for this job.",
+              default=Job.DEF_POLLING_INTERVAL, show_default=True)
+def submit(args, name, report_interval):
     """Submits a new job to the service daemon."""
     if not args:
         print("CLI error: Specify job.")
@@ -240,7 +240,6 @@ def submit(args, name, report_interval, no_poll):
     api = __get_api()  # type: Api
     cwd = os.getcwd()
     try:
-        report_interval = -1 if no_poll else report_interval
         job = api.submit(args, name=name, poll_interval=report_interval, cwd=cwd)
     except IOError:
         print("Cannot create job from given arguments! Do all files given exist? {command}".format(command=args))

--- a/meeshkan/__types__.py
+++ b/meeshkan/__types__.py
@@ -1,7 +1,6 @@
 """Module to define different types used through Meeshkan codebase"""
 from typing import NewType, Dict, Any, List
-from numbers import Number
 
 Token = NewType("Token", str)
 Payload = Dict[str, Any]
-HistoryByScalar = Dict[str, List[Number]]
+HistoryByScalar = Dict[str, List[float]]

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -4,6 +4,7 @@ import uuid
 from pathlib import Path
 from fnmatch import fnmatch
 
+import dill
 import Pyro4
 import Pyro4.errors
 
@@ -154,9 +155,9 @@ class Api(object):
         self.scheduler.report_scalar(pid, name, val)
 
     @Pyro4.expose
-    def condition(self, pid, vals, condition):
+    def condition(self, pid, condition, *vals):
         """Sets a condition for notifications"""
-
+        self.scheduler.condition(pid, *vals, condition=dill.loads(condition.encode('cp437')))
 
     @Pyro4.expose
     def get_updates(self, job_id, recent_only=True, img=False) -> Tuple[HistoryByScalar, Optional[str]]:

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -154,6 +154,11 @@ class Api(object):
         self.scheduler.report_scalar(pid, name, val)
 
     @Pyro4.expose
+    def condition(self, pid, vals, condition):
+        """Sets a condition for notifications"""
+
+
+    @Pyro4.expose
     def get_updates(self, job_id, recent_only=True, img=False) -> Tuple[HistoryByScalar, Optional[str]]:
         if not isinstance(job_id, uuid.UUID):
             job_id = uuid.UUID(job_id)

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -155,9 +155,9 @@ class Api(object):
         self.scheduler.report_scalar(pid, name, val)
 
     @Pyro4.expose
-    def condition(self, pid, condition, *vals):
+    def add_condition(self, pid, condition, *vals):
         """Sets a condition for notifications"""
-        self.scheduler.condition(pid, *vals, condition=dill.loads(condition.encode('cp437')))
+        self.scheduler.add_condition(pid, *vals, condition=dill.loads(condition.encode('cp437')))
 
     @Pyro4.expose
     def get_updates(self, job_id, recent_only=True, img=False) -> Tuple[HistoryByScalar, Optional[str]]:

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -1,7 +1,7 @@
 from enum import Enum
 import logging
 import subprocess
-from typing import Tuple, Optional, List, Union
+from typing import Tuple, Optional, List, Union, Callable, Any
 import uuid
 import datetime
 import os
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 from .config import JOBS_DIR
-from .tracker import TrackerBase
+from .tracker import TrackerBase, TrackerCondition
 
 LOGGER = logging.getLogger(__name__)
 
@@ -218,6 +218,19 @@ class Job(object):
     def __str__(self):
         return "Job: {executable}, #{number}, ({id}) - {status}".format(executable=self.executable, number=self.number,
                                                                         id=self.id, status=self.status.name)
+
+    def add_scalar_to_history(self, scalar_name, scalar_value) -> Optional[TrackerCondition]:
+        return self.scalar_history.add_tracked(scalar_name, scalar_value)
+
+    def add_condition(self, *val_names, condition: Callable[[List[Any]], bool]):
+        self.scalar_history.add_condition(*val_names, condition=condition)
+
+    def get_updates(self, name, plot, latest):
+        """Get latest updates for tracked scalar values. If plot == True, will also plot all tracked scalars.
+        If latest == True, returns only latest updates, otherwise returns entire history.
+        """
+        # Delegate to HistoryTracker
+        return self.scalar_history.get_updates(name, plot, latest)
 
     def cancel(self):
         """

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -159,7 +159,7 @@ class Job(object):
         self.status = JobStatus.CREATED
         self.name = name or "Job #{number}".format(number=self.number)
         self.description = desc or str(executable)
-        self.poll_time = poll_interval or Job.DEF_POLLING_INTERVAL
+        self.poll_time = poll_interval
 
     # Properties
 

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -222,15 +222,15 @@ class Job(object):
     def add_scalar_to_history(self, scalar_name, scalar_value) -> Optional[TrackerCondition]:
         return self.scalar_history.add_tracked(scalar_name, scalar_value)
 
-    def add_condition(self, *val_names, condition: Callable[[float], bool]):
-        self.scalar_history.add_condition(*val_names, condition=condition)
+    def add_condition(self, *val_names, condition: Callable[[float], bool], only_relevant: bool):
+        self.scalar_history.add_condition(*val_names, condition=condition, only_relevant=only_relevant)
 
-    def get_updates(self, name, plot, latest):
+    def get_updates(self, *names, plot, latest):
         """Get latest updates for tracked scalar values. If plot == True, will also plot all tracked scalars.
         If latest == True, returns only latest updates, otherwise returns entire history.
         """
         # Delegate to HistoryTracker
-        return self.scalar_history.get_updates(name, plot, latest)
+        return self.scalar_history.get_updates(*names, plot=plot, latest=latest)
 
     def cancel(self):
         """

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -222,7 +222,7 @@ class Job(object):
     def add_scalar_to_history(self, scalar_name, scalar_value) -> Optional[TrackerCondition]:
         return self.scalar_history.add_tracked(scalar_name, scalar_value)
 
-    def add_condition(self, *val_names, condition: Callable[[List[Any]], bool]):
+    def add_condition(self, *val_names, condition: Callable[[float], bool]):
         self.scalar_history.add_condition(*val_names, condition=condition)
 
     def get_updates(self, name, plot, latest):

--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -144,7 +144,7 @@ class Scheduler(object):
             raise JobNotFoundException(job_id=str(pid))
         return job_id[0]
 
-    def condition(self, pid, *vals, condition):
+    def add_condition(self, pid, *vals, condition):
         job_id = self.__get_job_by_pid(pid)
         self.submitted_jobs[job_id].add_condition(*vals, condition=condition)
 

--- a/meeshkan/core/tracker.py
+++ b/meeshkan/core/tracker.py
@@ -9,7 +9,6 @@ import logging
 import sys
 import asyncio
 
-from .job import Job
 from ..__types__ import HistoryByScalar
 from ..exceptions import TrackedScalarNotFoundException
 
@@ -27,20 +26,19 @@ __all__ = []  # type: List[str]
 
 
 class TrackingPoller(object):
-    DEF_POLLING_INTERVAL = 3600  # Default is notifications every hour.
     def __init__(self, notify_function: Callable[[uuid.UUID], Any]):
         self._notify = notify_function
 
-    async def poll(self, job: Job):
+    async def poll(self, job_id, poll_time: float):
         """Asynchronous polling function for scalars in given job"""
-        LOGGER.debug("Starting job tracking for job %s", job)
-        sleep_time = job.poll_time or TrackingPoller.DEF_POLLING_INTERVAL
+        LOGGER.debug("Starting job tracking for job %s", job_id)
+        sleep_time = poll_time
         try:
             while True:
                 await asyncio.sleep(sleep_time)  # Let other tasks run meanwhile
-                self._notify(job.id)  # Synchronously notify of changes.
+                self._notify(job_id)  # Synchronously notify of changes.
         except asyncio.CancelledError:
-            LOGGER.debug("Job tracking cancelled for job %s", job.id)
+            LOGGER.debug("Job tracking cancelled for job %s", job_id)
 
 
 class TrackerBase(object):

--- a/meeshkan/core/tracker.py
+++ b/meeshkan/core/tracker.py
@@ -47,6 +47,17 @@ class TrackerCondition(object):
     DEF_COOLDOWN_PERIOD = 30  # 30 seconds interval default cooldown period
     def __init__(self, *value_names: str, condition: Callable[[float], bool], title: str,
                  default_value=1, cooldown_period: int = None, only_relevant: bool = False):
+        """
+        Initializes a new condition for tracking
+        :param value_names: List of scalar names (strings)
+        :param condition: A callable that accepts as many values as the length of value_names
+        :param title: An optional title for this condition to be reported with the notification
+        :param default_value: A default value to use when scalar values are missing (default is 1)
+        :param cooldown_period: A cooldown interval (in seconds) from last notification, to prevent spamming when the
+            condition is met (default is 30 seconds)
+        :param only_relevant: A boolean flag to represent whether when this condition is met, only values relevant to
+            this condition should be reported (default is False, i.e. report all scalars for relevant job)
+        """
         if len(value_names) != len(inspect.signature(condition).parameters):
             raise RuntimeError("Number of arguments for condition {func} does not"
                                "match given number of arguments {vals}!".format(func=condition, vals=value_names))

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -10,6 +10,7 @@ from meeshkan.core.tracker import TrackerBase, TrackingPoller
 from meeshkan.core.job import Job
 import meeshkan.exceptions
 
+
 def test_tracker_history():
     tb = TrackerBase()
     tracked_value = 0
@@ -55,6 +56,7 @@ def test_get_updates_with_image():
     assert history[1] == 2
     assert os.path.isfile(fname)
     os.remove(fname)
+
 
 def test_get_latest_updates():
     tb = TrackerBase()
@@ -124,7 +126,7 @@ async def test_tracker_polling():
 
     t_start = time.time()
     event_loop = asyncio.get_event_loop()
-    task = event_loop.create_task(tp.poll(fake_job))
+    task = event_loop.create_task(tp.poll(fake_job, fake_job.poll_time))
     await task  # Wait for the task.cancel(), otherwise it would run indefinitely
     assert counter == 2
     tot_time = time.time() - t_start

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -83,7 +83,7 @@ def test_get_updates_with_name():
     tb = TrackerBase()
     tb.add_tracked("tracked_value", 1)
     tb.add_tracked("another value", 1)
-    history, _ = tb.get_updates(name="tracked_value", plot=False, latest=True)
+    history, _ = tb.get_updates("tracked_value", plot=False, latest=True)
     assert len(history) == 1
     assert len(history["tracked_value"]) == 1
 


### PR DESCRIPTION
* Moves `TrackerBase` inside `Job` (scalar history)
* Adds conditional notifications via `meeshkan.condition(*value_names, condition=...)`
* Adds cooldown period to conditional notifications
* Changes `matplotlib` backend to `svg` (static one, no `show()`).
* Single points are now scattered instead of being ignored

- [x] Update README and examples
- [ ] **Optional**: Check `matplotlib` backend on MacOS