### PR TITLE
Plot scalars by shared index/wall time

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -222,8 +222,12 @@ def report(job_identifier):
     if not job_id:
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
-    print("Latest scalar reports for '{name}'".format(api.get_job(job_id).name))
-    print(tabulate.tabulate(api.get_updates(job_id), headers="keys", tablefmt="fancy_grid"))
+    print("Latest scalar reports for '{name}'".format(name=api.get_job(job_id).name))
+    scalar_history = api.get_updates(job_id)
+    values_without_time = dict()  # Remove timestamp from report
+    for scalar_name, values_with_time in scalar_history.items():
+        values_without_time[scalar_name] = [timevalue.value for timevalue in values_with_time]
+    print(tabulate.tabulate(values_without_time, headers="keys", tablefmt="fancy_grid"))
 
 
 @cli.command()
@@ -321,7 +325,7 @@ def notifications(job_identifier):
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
     notification_history = api.get_notification_history(job_id)
-    print("Notifications for '{name}'".format(api.get_job(job_id).name))
+    print("Notifications for '{name}'".format(name=api.get_job(job_id).name))
     # Create index list based on longest history available
     row_ids = range(1, max([len(history) for history in notification_history.values()])+1)
     print(tabulate.tabulate(notification_history, headers="keys", showindex=row_ids, tablefmt="fancy_grid"))

--- a/meeshkan/__types__.py
+++ b/meeshkan/__types__.py
@@ -3,9 +3,9 @@ from typing import NewType, Dict, Any, List, Tuple
 import time
 
 class ScalarTimePairing(object):
-    def __init__(self, value: float):
+    def __init__(self, value: float, timevalue=None):
         self.value = value
-        self.time = time.monotonic()
+        self.time = timevalue if timevalue is not None else time.monotonic()
 
 Token = NewType("Token", str)
 Payload = Dict[str, Any]

--- a/meeshkan/__types__.py
+++ b/meeshkan/__types__.py
@@ -1,6 +1,13 @@
 """Module to define different types used through Meeshkan codebase"""
-from typing import NewType, Dict, Any, List
+from typing import NewType, Dict, Any, List, Tuple
+import time
+
+class ScalarTimePairing(object):
+    def __init__(self, value: float):
+        self.value = value
+        self.time = time.monotonic()
 
 Token = NewType("Token", str)
 Payload = Dict[str, Any]
-HistoryByScalar = Dict[str, List[float]]
+# Keys are scalar names, value is a list of tuples, indicating wall time and value for that scalar
+HistoryByScalar = Dict[str, List[ScalarTimePairing]]

--- a/meeshkan/core/tracker.py
+++ b/meeshkan/core/tracker.py
@@ -11,7 +11,7 @@ import sys
 import asyncio
 import inspect
 
-from ..__types__ import HistoryByScalar
+from ..__types__ import HistoryByScalar, ScalarTimePairing
 from ..exceptions import TrackedScalarNotFoundException
 
 TF_EXISTS = True
@@ -99,16 +99,20 @@ class TrackerBase(object):
         # Last index which was submitted to cloud, used for statistics
         self._last_index = dict()  # type: Dict[str, int]
         self._conditions = list()  # type: List[TrackerCondition]
+        self._shared_index = 0
 
     def add_tracked(self, val_name: str, value: float) -> Optional[TrackerCondition]:
         # Add/create to dictionaries
-        self._history_by_scalar.setdefault(val_name, list()).append(value)
+        if val_name in self._history_by_scalar and self._history_by_scalar[val_name][-1].time == self._shared_index:
+            self._shared_index += 1
+        value_with_time = ScalarTimePairing(value, self._shared_index)
+        self._history_by_scalar.setdefault(val_name, list()).append(value_with_time)
         self._last_index.setdefault(val_name, -1)  # Initial index
         # Verify with conditions
         for condition in self._conditions:
             if val_name in condition:  # Condition is relevant for this scalar
                 existing_values = [name for name in condition.names if name in self._history_by_scalar]
-                kwargs = {name: self._history_by_scalar[name][-1] for name in existing_values}
+                kwargs = {name: self._history_by_scalar[name][-1].value for name in existing_values}
                 if condition(**kwargs):
                     return condition
         return None
@@ -138,15 +142,27 @@ class TrackerBase(object):
 
         has_plotted = False
         plt.clf()  # Clear figure
+        longest_iteration = 0  # Used for relabeling the x-axis by "iterations" or "reports"
         for tag, vals in history.items():  # All all scalar values to plot
             if vals:  # Some values exist
                 has_plotted = True
+                time_axis = list()
+                value_axis = list()
+                for value_with_time in vals:  # Separate axes
+                    time_axis.append(value_with_time.time)
+                    value_axis.append(value_with_time.value)
+                longest_iteration = max(longest_iteration, len(value_axis))
                 if len(vals) > 1:
-                    plt.plot(vals, label=tag)
+                    plt.plot(time_axis, value_axis, label=tag, linewidth=1)
                 else:  # scatter=plot the single point on x=0 :shrug:
-                    plt.scatter(0, vals, label=tag)
+                    plt.scatter(time_axis, value_axis, label=tag)
 
         if has_plotted:
+            # Relabel the x-axis for longest number of reports
+            # TODO - this can probably be improved with self._shared_index
+            locs, _ = plt.xticks()
+            stepsize = longest_iteration // len(locs) or 1  # Minimal step size of 1
+            plt.xticks(locs, range(0, longest_iteration, stepsize))
             plt.legend(loc='upper right')
             if title is not None:  # Title if given
                 plt.title(title)
@@ -181,7 +197,7 @@ class TrackerBase(object):
                 if name not in self._history_by_scalar:
                     raise TrackedScalarNotFoundException(name=name)
 
-            data = dict()  # type: Dict[str, List[float]]
+            data = dict()  # type: HistoryByScalar
             for value_name, values in self._history_by_scalar.items():
                 for name in names:
                     if name == value_name:

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -22,12 +22,12 @@ def test_tracker_history():
     assert "tracked_value" in history  # Keeps correct naming
     history = history["tracked_value"]
     assert len(history) == 2  # Correct number of values tracked
-    assert history[0] == 0
-    assert history[1] == 1e-7
+    assert history[0].value == 0
+    assert history[1].value == 1e-7
 
     tb.add_tracked("another value", -2.3)  # Checks multiple value names
     assert len(tb._history_by_scalar) == 2
-    assert tb._history_by_scalar["another value"][0] == -2.3
+    assert tb._history_by_scalar["another value"][0].value == -2.3
 
 
 def test_generate_image():
@@ -52,8 +52,8 @@ def test_get_updates_with_image():
     assert len(history) == 1
     history = history["tracked_value"]
     assert len(history) == 2
-    assert history[0] == 1
-    assert history[1] == 2
+    assert history[0].value == 1
+    assert history[1].value == 2
     assert os.path.isfile(fname)
     os.remove(fname)
 
@@ -67,7 +67,7 @@ def test_get_latest_updates():
     history = history["tracked_value"]
     assert fname is None
     assert len(history) == 3
-    assert history == [1, 2.2, -4.1]
+    assert [timevalue.value for timevalue in history] == [1, 2.2, -4.1]
 
     tb.add_tracked("tracked_value", 0)
     history, _ = tb.get_updates(plot=False)


### PR DESCRIPTION
* Scalar history now couples each scalar value with either index or walltime (if index not provided)
* Index is shared across scalars by default; each time a scalar is reported and the index collides, it is incremented
**Results:**
- Maintains scale across scalar reports
- No gaps between pauses for scalars (e.g. switching from training to test to training)