### PR TITLE
Fix bug when importing from another module

### DIFF
--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -56,4 +56,5 @@ def add_condition(*vals, condition, only_reported=False):
     pid = os.getpid()
     with Service().api as proxy:
         # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
-        proxy.add_condition(pid, dill.dumps(condition).decode('cp437'), only_reported, *vals)
+        # recurse==True also packs relevant modules etc and imports if needed and declared in a different module...
+        proxy.add_condition(pid, dill.dumps(condition, recurse=True).decode('cp437'), only_reported, *vals)

--- a/meeshkan/__types__.py
+++ b/meeshkan/__types__.py
@@ -2,12 +2,14 @@
 from typing import NewType, Dict, Any, List, Tuple
 import time
 
-class ScalarTimePairing(object):
-    def __init__(self, value: float, timevalue=None):
+class ScalarIndexPairing(object):
+    """Represents a coupling between a scalar value and an index. If no index is provided, time.monotonic() is used
+    to maintain consistent scale."""
+    def __init__(self, value: float, idx=None):
         self.value = value
-        self.time = timevalue if timevalue is not None else time.monotonic()
+        self.idx = idx if idx is not None else time.monotonic()
 
 Token = NewType("Token", str)
 Payload = Dict[str, Any]
 # Keys are scalar names, value is a list of tuples, indicating wall time and value for that scalar
-HistoryByScalar = Dict[str, List[ScalarTimePairing]]
+HistoryByScalar = Dict[str, List[ScalarIndexPairing]]


### PR DESCRIPTION
- [x] Fixes bug when trying to call `add_condition` in an imported module from another script.
  - Uses the `recurse` flag for `dill`. In effect, this means a lot more is being serialized which would cause a large overhead if it was transmitted over the network. Luckily this is local so it shouldn't be a problem.
  - Needs further feedback
- [x] Replaces "time" attribute for scalar and index coupling with "index". Using `time.monotonic()` is strictly a fallback if no index is provided.