### PR TITLE
Use fork instead of spawn.

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -72,17 +72,6 @@ def __build_api(config: meeshkan.config.Configuration,
     # This MUST be serializable so it can be sent to the process starting Pyro daemon with forkserver
     def build_api(service: Service) -> Api:
         # Build all dependencies except for `Service` instance (attached when daemonizing)
-        import inspect
-        # Disable pylint tests for reimport
-        import sys as sys_  # pylint: disable=reimported
-        import os as os_  # pylint: disable=reimported
-
-        # TODO - do we need this?
-        current_file = inspect.getfile(inspect.currentframe())
-        current_dir = os_.path.split(current_file)[0]
-        cmd_folder = os_.path.realpath(os_.path.abspath(os_.path.join(current_dir, '../')))
-        if cmd_folder not in sys_.path:
-            sys_.path.insert(0, cmd_folder)
 
         from meeshkan.core.cloud import CloudClient as CloudClient_
         from meeshkan.core.api import Api as Api_
@@ -91,7 +80,6 @@ def __build_api(config: meeshkan.config.Configuration,
         from meeshkan.core.scheduler import Scheduler, QueueProcessor
         from meeshkan.core.config import ensure_base_dirs as ensure_base_dirs_
         from meeshkan.core.logger import setup_logging as setup_logging_
-
 
         ensure_base_dirs_()
         setup_logging_(silent=True)
@@ -190,7 +178,7 @@ def start():
     try:
         __notify_service_start(config, credentials)
         build_api_serialized = dill.dumps(__build_api(config, credentials))
-        pyro_uri = service.start(mp.get_context("spawn"), build_api_serialized=build_api_serialized)
+        pyro_uri = service.start(mp.get_context("fork"), build_api_serialized=build_api_serialized)
         print('Service started.')
         return pyro_uri
     except meeshkan.exceptions.UnauthorizedRequestException as ex:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -8,7 +8,7 @@ from meeshkan.core.api import Api
 from meeshkan.core.scheduler import Scheduler, QueueProcessor
 from meeshkan.core.tasks import TaskPoller
 
-MP_CTX = mp.get_context("spawn")
+MP_CTX = mp.get_context("fork")
 
 
 def _build_api(service: Service):


### PR DESCRIPTION
Starting the client in macOS fails in certain Python virtual environments with 
```
objc[60320]: +[NSValue initialize] may have been in progress in another thread when fork() was called.
objc[60320]: +[NSValue initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```
This is most likely related to how the daemon process is created when starting the client. It has been difficult to reproduce this as it seems to happen only in certain environments with certain dependencies. 

The process creation method was changed from `fork` (default) to `spawn` in https://github.com/Meeshkan/meeshkan-client/pull/67 which seemed to fix similar crashes at the time. The crashes might have been related to using an interactive backend instead of using the "wrong" process creation method. Backend has been [fchanged](https://github.com/Meeshkan/meeshkan-client/blob/3cfb40fe92f89ddc78c668e6a2cdc9e8be941f3c/meeshkan/core/tracker.py#L140) to `svg` now.

Using `fork` instead of `spawn` seems to fix the current error. It also simplifies the process creation as  "the child process, when it begins, is effectively identical to the parent process. All resources of the parent are inherited by the child process. Note that safely forking a multithreaded process is problematic." ([source](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods))