### PR TITLE
Move job status helpers to JobStatus as methods.

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -260,8 +260,8 @@ def cancel_job(job_identifier):
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
     api = __get_api()
-    job = api.get_job(job_id)
-    if job.is_running:
+    job = api.get_job(job_id)  # type: Job
+    if job.status.is_running:
         res = input("Job '{name}' is currently running! "
                     "Are you sure you want to cancel it? y/[N]: ".format(name=job.name))
         if not res or res.lower() != "y":  # Any response other than "Y"/"y"

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -27,6 +27,24 @@ class JobStatus(Enum):
     FAILED = 5  # Failed due to some errors
     CANCELLED_BY_USER = 10  # Marked cancelled by service
 
+    @property
+    def is_launched(self):
+        """Returns whether or not the job has been running at all"""
+        return self == JobStatus.RUNNING or self.is_processed
+
+    @property
+    def is_running(self):
+        """Returns whether or not the job is currently running"""
+        return self == JobStatus.RUNNING
+
+    @property
+    def is_processed(self):
+        return self in [JobStatus.CANCELED, JobStatus.FAILED, JobStatus.FINISHED]
+
+    @property
+    def stale(self):
+        return self == JobStatus.CANCELLED_BY_USER
+
 
 CANCELED_RETURN_CODES = [-2, -3, -9, -15]  # Signals indicating user-initiated abort
 SUCCESS_RETURN_CODE = [0]  # Completeness, extend later (i.e. consider > 0 return codes as success with message?)
@@ -161,26 +179,6 @@ class Job(object):
         self.description = desc or str(executable)
         self.poll_time = poll_interval
 
-    # Properties
-
-    @property
-    def is_launched(self):
-        """Returns whether or not the job has been running at all"""
-        return self.status == JobStatus.RUNNING or self.is_processed
-
-    @property
-    def is_running(self):
-        """Returns whether or not the job is currently running"""
-        return self.status == JobStatus.RUNNING
-
-    @property
-    def is_processed(self):
-        return self.status in [JobStatus.CANCELED, JobStatus.FAILED, JobStatus.FINISHED]
-
-    @property
-    def stale(self):
-        return self.status == JobStatus.CANCELLED_BY_USER
-
     @property
     def pid(self):
         return self.executable.pid
@@ -212,8 +210,8 @@ class Job(object):
             else:
                 self.status = JobStatus.FAILED
             return return_code
-        except IOError as ex:
-            LOGGER.exception("Could not execute, is the job executable? Job: %s", str(self.executable))
+        except Exception as ex:
+            LOGGER.exception("Failed executing job")
             self.status = JobStatus.FAILED
             raise ex
 
@@ -243,7 +241,7 @@ class Job(object):
         :return:
         """
         self.terminate()
-        if not self.is_launched:
+        if not self.status.is_launched:
             self.status = JobStatus.CANCELLED_BY_USER  # Safe to modify as worker has not started
 
     def to_dict(self):

--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -105,7 +105,7 @@ class Scheduler(object):
 
     def _handle_job(self, job: Job) -> None:
         LOGGER.debug("Handling job: %s", job)
-        if job.stale:
+        if job.status.stale:
             return
         self._running_job = job
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -117,7 +117,7 @@ def test_terminating_job():
         job = get_job(executable=FutureWaitingExecutable(future=Future()))
         scheduler.submit_job(job)
         # Block until job launched
-        wait_for_true(lambda: job.is_launched)
+        wait_for_true(lambda: job.status.is_launched)
         scheduler.stop_job(job_id=job.id)
     # Job status can be checked only after clean-up is performed
     assert job.status == JobStatus.CANCELED, "The job was cancelled shortly after it was launched!"
@@ -139,10 +139,10 @@ def test_canceling_job():
         wait_for_true(scheduler._job_queue.empty)
 
     # Job status should be checked only after clean-up is performed
-    assert job1.is_launched, "The job was launched as soon as possible"
+    assert job1.status.is_launched, "The job was launched as soon as possible"
     assert job1.status == JobStatus.FINISHED, "And was done finished once called `set_result`"
 
-    assert not job2.is_launched, "The job was never supposed to launch"
+    assert not job2.status.is_launched, "The job was never supposed to launch"
     assert job2.status == JobStatus.CANCELLED_BY_USER, "The job was cancelled immediately after submission, while " \
                                                        "another job was running"
 
@@ -156,7 +156,7 @@ def test_stopping_scheduler():
         while job.pid is None:
             time.sleep(0.1)
         # Exit scheduler, should not block as `job.cancel()` is called
-    assert job.is_launched, "Job has started (as we wait for the PID to be available)"
+    assert job.status.is_launched, "Job has started (as we wait for the PID to be available)"
     assert job.status == JobStatus.CANCELED, "The job was cancelled as the scheduler __exit__'d"
 
 


### PR DESCRIPTION
Move  `is_launched` and other similar methods to `JobStatus` class to make `Job` smaller.