### PR TITLE
Monitor SageMaker updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ jobs:
     vmImage: 'macOS-10.13'
   timeoutInMinutes: 10
   strategy:
-    maxParallel: 2
+    maxParallel: 1
     matrix:
       Python36:
         python.version: '3.6'
@@ -24,7 +24,7 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-    maxParallel: 2
+    maxParallel: 1
 
   steps:
   - template: azure-steps.yml

--- a/azure-steps.yml
+++ b/azure-steps.yml
@@ -7,7 +7,7 @@ steps:
 - script: python -m pip install --upgrade pip setuptools wheel
   displayName: 'Install tools'
 
-- script: pip install -e .[dev]
+- script: pip install --upgrade -e .[dev]
   displayName: 'Installing dev version'
 
 - script: |

--- a/azure-steps.yml
+++ b/azure-steps.yml
@@ -11,7 +11,7 @@ steps:
   displayName: 'Installing dev version'
 
 - script: |
-    pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=meeshkan --cov-report=xml --cov-report=html --cov-fail-under=80
+    pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=meeshkan --cov-report=xml --cov-report=html --cov-fail-under=80
   displayName: 'Test with pytest'
 
 - script: |

--- a/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
+++ b/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
@@ -260,8 +260,7 @@
     "float_pattern = \"([0-9\\\\.]+)\"\n",
     "epoch_pattern = \"Epoch={}\".format(float_pattern)\n",
     "val_loss_pattern = \"ValidationLoss={}\".format(float_pattern)\n",
-    "training_loss_pattern = \"TrainingLoss={}\".format(float_pattern)\n",
-    "learning_rate_pattern = \"LearningRate={}\".format(float_pattern)"
+    "training_loss_pattern = \"TrainingLoss={}\".format(float_pattern)"
    ]
   },
   {
@@ -279,7 +278,6 @@
    "source": [
     "from sagemaker.pytorch import PyTorch\n",
     "\n",
-    "\n",
     "estimator = PyTorch(entry_point='train.py',\n",
     "                    role=role,\n",
     "                    framework_version='1.0.0',\n",
@@ -293,10 +291,9 @@
     "                    metric_definitions=[\n",
     "                        {'Name': 'epoch', 'Regex': epoch_pattern},\n",
     "                        {'Name': 'val:loss', 'Regex': val_loss_pattern},\n",
-    "                        {'Name': 'train:loss', 'Regex': training_loss_pattern},\n",
-    "                        {'Name': 'learning_rate', 'Regex': learning_rate_pattern}\n",
+    "                        {'Name': 'train:loss', 'Regex': training_loss_pattern}\n",
     "                    ]\n",
-    "                   )\n"
+    "                   )"
    ]
   },
   {

--- a/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
+++ b/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
@@ -4,8 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Word-level language modeling using PyTorch and Meeshkan\n",
-    "Hacked from [this fantastic tutorial](https://github.com/awslabs/amazon-sagemaker-examples/tree/master/sagemaker-python-sdk/pytorch_lstm_word_language_model) for using PyTorch in SageMaker."
+    "# Word-level language modeling using PyTorch and Meeshkan\n"
    ]
   },
   {
@@ -82,7 +81,7 @@
     "1. [Setup](#Setup)\n",
     "1. [Data](#Data)\n",
     "1. [Train](#Train)\n",
-    "1. [Host](#Host)\n",
+    "1. [Monitor with Meeshkan](#Monitor)\n",
     "\n",
     "---\n",
     "\n",
@@ -249,7 +248,7 @@
    "metadata": {},
    "source": [
     "### Define the metrics to capture\n",
-    "Our training script prints, for example, rows such as 'TrainingLoss=2.2342', so tell SageMaker to capture those."
+    "Our training script prints, for example, rows such as 'TrainingLoss=2.2342', so tell SageMaker to capture those. **Meeshkan can only notify you of the metrics that you define here**. Note that if you use built-in Amazon algorithms, those define their own metric definitions and will be automatically watched."
    ]
   },
   {
@@ -285,7 +284,7 @@
     "                    role=role,\n",
     "                    framework_version='1.0.0',\n",
     "                    train_instance_count=1,\n",
-    "                    train_instance_type='ml.m4.xlarge',\n",
+    "                    train_instance_type='ml.m4.xlarge',  # Use e.g. `ml.p2.xlarge` to train faster\n",
     "                    source_dir='source',\n",
     "                    hyperparameters={\n",
     "                        'epochs': 2,\n",
@@ -316,7 +315,7 @@
    "source": [
     "from time import gmtime, strftime\n",
     "\n",
-    "job_name = 'pytorch-rnn-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "job_name = 'pytorch-meeshkan-rnn-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
     "\n",
     "estimator.fit({'training': inputs}, job_name=job_name, wait=False)\n",
     "print(\"Submitted job {:s}\".format(job_name))"
@@ -326,7 +325,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Start monitoring the job with Meeshkan, checking for updates every minute"
+    "You can check the status of the job with\n",
+    "```python\n",
+    "sagemaker_client.describe_training_job(TrainingJobName=job_name)['TrainingJobStatus']\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monitor\n",
+    "Start monitoring the job with Meeshkan, checking for updates every minute. You will be notified via Slack when new metrics are posted by the SageMaker job."
    ]
   },
   {
@@ -343,7 +353,7 @@
    "metadata": {},
    "source": [
     "### Stop the job\n",
-    "For demonstration purposes, let us stop the job using low-level `boto3` client. Stopping the job may take a few minutes, but once it's done, you'll get a Slack notification from Meeshkan of your job being finished."
+    "For demonstration purposes, you can stop the job using the low-level `boto3` client as shown below. Stopping the job may take a few minutes, but once it's done, you'll get a Slack notification from Meeshkan of your job being finished."
    ]
   },
   {
@@ -355,34 +365,6 @@
     "import boto3\n",
     "sagemaker_client = boto3.client('sagemaker')\n",
     "sagemaker_client.stop_training_job(TrainingJobName=job_name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can check the current status of the job with\n",
-    "```python\n",
-    "sagemaker_client.describe_training_job(TrainingJobName=job_name)['TrainingJobStatus']\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Getting analytics for the job (once it's started)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "analytics = sagemaker.analytics.TrainingJobAnalytics(training_job_name=job_name)\n",
-    "analytics_df = analytics.dataframe()\n",
-    "analytics_df"
    ]
   }
  ],

--- a/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
+++ b/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
@@ -12,15 +12,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup `meeshkan`"
+    "## Setup"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Install\n",
-    "You may have to **restart the kernel (`Kernel` -> `Restart`) for the changes to have effect.**"
+    "### Install requirements\n",
+    "Using `meeshkan` with sagemaker requires installing both Python SDKs. Note that if you have installed `meeshkan` previously, you may have to **restart the Jupyter kernel (`Kernel` -> `Restart`) to have the dependency updated.**"
    ]
   },
   {
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade meeshkan  # Install from PyPI"
+    "!pip install --upgrade meeshkan sagemaker"
    ]
   },
   {
@@ -38,14 +38,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import meeshkan"
+    "import meeshkan\n",
+    "import sagemaker"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Start Meeshkan agent using the `token` you got when signing up at [meeshkan.com](https://meeshkan.com)\n",
+    "### Start the Meeshkan agent\n",
+    "The Meeshkan agent is a daemonized process monitoring your jobs in the background and notifying you when events happen. The command `meeshkan init(token=YOUR_TOKEN)` starts the agent using the token you got when signing up at [meeshkan.com](https://meeshkan.com).\n",
     "The token is stored to a local file at `~/.meeshkan/credentials`, so you only need to include the token here _once_."
    ]
   },
@@ -94,25 +96,14 @@
     "\n",
     "## Setup\n",
     "\n",
-    "_This notebook was created and tested on an ml.p2.xlarge notebook instance._\n",
-    "\n",
-    "Let's first install [SageMaker Python SDK](https://github.com/aws/sagemaker-python-sdk):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install --upgrade sagemaker"
+    "_This notebook was created and tested on an ml.p2.xlarge notebook instance._"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's then create a SageMaker session and specify:\n",
+    "Let's create a SageMaker session and specify:\n",
     "\n",
     "- The S3 bucket and prefix that you want to use for training and model data.  This should be within the same region as the Notebook Instance, training, and hosting.\n",
     "- The IAM role arn used to give training and hosting access to your data. See [the documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) for how to create these.  Note, if more than one role is required for notebook instances, training, and/or hosting, please replace the sagemaker.get_execution_role() with appropriate full IAM role arn string(s)."
@@ -124,15 +115,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sagemaker\n",
-    "\n",
     "sagemaker_session = sagemaker.Session()\n",
     "\n",
     "bucket = sagemaker_session.default_bucket()\n",
     "prefix = 'sagemaker/DEMO-pytorch-rnn-lstm'\n",
     "\n",
     "role = sagemaker.get_execution_role()  # If you are running the notebook in notebook instance\n",
-    "# If you are running the notebook locally, fill the appropriate execution role ARN here.\n",
+    "# If you are running the notebook locally, fill in the appropriate execution role ARN here.\n",
     "# role = \"EXECUTOR_ROLE_ARN_HERE\""
    ]
   },
@@ -333,10 +322,7 @@
    "metadata": {},
    "source": [
     "### Stop the job\n",
-    "For demonstration purposes, let us stop the job using low-level `boto3` client. Stopping the job may take a few minutes, but once it's done, you'll get a Slack notification from Meeshkan of your job being finished. You can check the current status of the job with\n",
-    "```python\n",
-    "sagemaker_client.describe_training_job(TrainingJobName=job_name)['TrainingJobStatus']\n",
-    "```"
+    "For demonstration purposes, let us stop the job using low-level `boto3` client. Stopping the job may take a few minutes, but once it's done, you'll get a Slack notification from Meeshkan of your job being finished."
    ]
   },
   {
@@ -348,6 +334,16 @@
     "import boto3\n",
     "sagemaker_client = boto3.client('sagemaker')\n",
     "sagemaker_client.stop_training_job(TrainingJobName=job_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can check the current status of the job with\n",
+    "```python\n",
+    "sagemaker_client.describe_training_job(TrainingJobName=job_name)['TrainingJobStatus']\n",
+    "```"
    ]
   },
   {

--- a/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
+++ b/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
@@ -248,6 +248,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Define the metrics to capture\n",
+    "Our training script prints, for example, rows such as 'TrainingLoss=2.2342', so tell SageMaker to capture those."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_pattern = \"([0-9\\\\.]+)\"\n",
+    "epoch_pattern = \"Epoch={}\".format(float_pattern)\n",
+    "val_loss_pattern = \"ValidationLoss={}\".format(float_pattern)\n",
+    "training_loss_pattern = \"TrainingLoss={}\".format(float_pattern)\n",
+    "learning_rate_pattern = \"LearningRate={}\".format(float_pattern)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Create a PyTorch estimator"
    ]
   },
@@ -259,14 +280,12 @@
    "source": [
     "from sagemaker.pytorch import PyTorch\n",
     "\n",
-    "epoch_pattern = \"Epoch=([0-9\\\\.]+)\"\n",
-    "loss_pattern = \"ValidationLoss=([0-9\\\\.]+)\"\n",
     "\n",
     "estimator = PyTorch(entry_point='train.py',\n",
     "                    role=role,\n",
     "                    framework_version='1.0.0',\n",
     "                    train_instance_count=1,\n",
-    "                    train_instance_type='ml.p2.xlarge',\n",
+    "                    train_instance_type='ml.m4.xlarge',\n",
     "                    source_dir='source',\n",
     "                    hyperparameters={\n",
     "                        'epochs': 2,\n",
@@ -274,7 +293,9 @@
     "                    },\n",
     "                    metric_definitions=[\n",
     "                        {'Name': 'epoch', 'Regex': epoch_pattern},\n",
-    "                        {'Name': 'val:loss', 'Regex': loss_pattern}\n",
+    "                        {'Name': 'val:loss', 'Regex': val_loss_pattern},\n",
+    "                        {'Name': 'train:loss', 'Regex': training_loss_pattern},\n",
+    "                        {'Name': 'learning_rate', 'Regex': learning_rate_pattern}\n",
     "                    ]\n",
     "                   )\n"
    ]

--- a/examples/sagemaker/source/train.py
+++ b/examples/sagemaker/source/train.py
@@ -193,7 +193,7 @@ def train():
         if batch % args.log_interval == 0 and batch > 0:
             cur_loss = total_loss / args.log_interval
             print('TrainingLoss={0:.3f}'.format(cur_loss))
-            print('LearningRate={:02.2f}'.format(lr))
+            # print('LearningRate={:02.2f}'.format(lr))
             elapsed = time.time() - start_time
             print('| epoch {:3d} | {:5d}/{:5d} batches | lr {:02.2f} | ms/batch {:5.2f} | '
                   'loss {:5.2f} | ppl {:8.2f}'.format(

--- a/examples/sagemaker/source/train.py
+++ b/examples/sagemaker/source/train.py
@@ -192,8 +192,8 @@ def train():
 
         if batch % args.log_interval == 0 and batch > 0:
             cur_loss = total_loss / args.log_interval
-            print('TrainingLoss={:5.2f}'.format(cur_loss))  # Fails
-            print('LearningRate={:02:2f}'.format(lr))
+            print('TrainingLoss={:5.2f}'.format(cur_loss))
+            print('LearningRate={:02.2f}'.format(lr))
             elapsed = time.time() - start_time
             print('| epoch {:3d} | {:5d}/{:5d} batches | lr {:02.2f} | ms/batch {:5.2f} | '
                   'loss {:5.2f} | ppl {:8.2f}'.format(

--- a/examples/sagemaker/source/train.py
+++ b/examples/sagemaker/source/train.py
@@ -192,7 +192,7 @@ def train():
 
         if batch % args.log_interval == 0 and batch > 0:
             cur_loss = total_loss / args.log_interval
-            print('TrainingLoss={:5.2f}'.format(cur_loss))
+            print('TrainingLoss={0:.3f}'.format(cur_loss))
             print('LearningRate={:02.2f}'.format(lr))
             elapsed = time.time() - start_time
             print('| epoch {:3d} | {:5d}/{:5d} batches | lr {:02.2f} | ms/batch {:5.2f} | '
@@ -214,7 +214,7 @@ for epoch in range(1, args.epochs+1):
     val_loss = evaluate(val_data)
     print('-' * 89)
     print('Epoch={:d}'.format(epoch))
-    print('ValidationLoss={:5.2f}'.format(val_loss))
+    print('ValidationLoss={0:.3f}'.format(val_loss))
     print('| end of epoch {:3d} | time: {:5.2f}s | valid loss {:5.2f} | '
           'valid ppl {:8.2f}'.format(epoch, (time.time() - epoch_start_time),
                                      val_loss, math.exp(val_loss)))

--- a/examples/sagemaker/source/train.py
+++ b/examples/sagemaker/source/train.py
@@ -192,6 +192,8 @@ def train():
 
         if batch % args.log_interval == 0 and batch > 0:
             cur_loss = total_loss / args.log_interval
+            print('TrainingLoss={:5.2f}'.format(cur_loss))  # Fails
+            print('LearningRate={:02:2f}'.format(lr))
             elapsed = time.time() - start_time
             print('| epoch {:3d} | {:5d}/{:5d} batches | lr {:02.2f} | ms/batch {:5.2f} | '
                   'loss {:5.2f} | ppl {:8.2f}'.format(
@@ -212,7 +214,7 @@ for epoch in range(1, args.epochs+1):
     val_loss = evaluate(val_data)
     print('-' * 89)
     print('Epoch={:d}'.format(epoch))
-    print('ValidationLoss={:f}'.format(val_loss))
+    print('ValidationLoss={:5.2f}'.format(val_loss))
     print('| end of epoch {:3d} | time: {:5.2f}s | valid loss {:5.2f} | '
           'valid ppl {:8.2f}'.format(epoch, (time.time() - epoch_start_time),
                                      val_loss, math.exp(val_loss)))

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -17,3 +17,17 @@ __all__ += ["save_token", "start", "restart_agent", "init"]
 del core  # Clean-up (make `meeshkan.core` unavailable)
 del api
 # del utils  # This is still required by mocking tests
+
+__doc__ = """
+Meeshkan - Monitoring and remote-control tool for machine learning jobs
+=====================================================================
+**meeshkan** is a Python package providing control to your machine learning jobs. 
+
+Main Features
+-------------
+Here are just a few of the things meeshkan can do:
+  - Notify you of your job's progress at fixed intervals.
+  - Notify you when certain events happen
+  - Allow you to control training jobs remotely
+  - Allow monitoring Amazon SageMaker jobs
+"""

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -156,10 +156,13 @@ def cancel_job(job_identifier):
 @cli.command()
 def stop():
     """Stops the service daemon."""
-    api = _get_api()  # type: Api
-    api.stop()
-    LOGGER.info("Service stopped.")
-    print("Service stopped.")
+    try:
+        api = _get_api()  # type: Api
+        api.stop()
+        LOGGER.info("Service stopped.")
+        print("Service stopped.")
+    except meeshkan.exceptions.AgentNotAvailableException:
+        pass
 
 
 @cli.command(name='list')

--- a/meeshkan/build.py
+++ b/meeshkan/build.py
@@ -27,7 +27,8 @@ def build_api(service, cloud_client):
 
     scheduler = Scheduler(queue_processor=queue_processor, notifier=notifier_collection)
 
-    sagemaker_job_monitor = SageMakerJobMonitor(notify_finish=notifier_collection.notify_job_end)
+    sagemaker_job_monitor = SageMakerJobMonitor(notify_start=notifier_collection.notify_job_start,
+                                                notify_finish=notifier_collection.notify_job_end)
 
     api = Api(scheduler=scheduler,
               service=service,

--- a/meeshkan/build.py
+++ b/meeshkan/build.py
@@ -28,6 +28,7 @@ def build_api(service, cloud_client):
     scheduler = Scheduler(queue_processor=queue_processor, notifier=notifier_collection)
 
     sagemaker_job_monitor = SageMakerJobMonitor(notify_start=notifier_collection.notify_job_start,
+                                                notify_update=notifier_collection.notify,
                                                 notify_finish=notifier_collection.notify_job_end)
 
     api = Api(scheduler=scheduler,

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -197,6 +197,7 @@ class Api(object):
     @Pyro4.expose
     def stop(self):
         if self.__was_shutdown:
+            LOGGER.warning("Agent API was shutdown twice.")
             return
         self.__was_shutdown = True
         self.scheduler.stop()

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -192,9 +192,8 @@ class SageMakerJobMonitor:
             self.notify_finish(job)
 
     @staticmethod
-    def dataframe_diff(df_new: pd.DataFrame, df_old: pd.DataFrame):
-        df_diff = (df_new != df_old).stack()
-        return df_new[df_diff]
+    def get_new_records(df_new: pd.DataFrame, df_old: pd.DataFrame):
+        return df_new.loc[len(df_old):len(df_new)].to_dict(orient='records')
 
     async def poll_updates(self, job: BaseJob):
         if not isinstance(job, SageMakerJob):
@@ -229,7 +228,7 @@ class SageMakerJobMonitor:
                         None,
                         self.sagemaker_helper.get_training_job_analytics_df, job.name)
                     if previous_metrics_df is not None:
-                        # diff = SageMakerJobMonitor.dataframe_diff(df_new=metrics_df, df_old=previous_metrics_df)
+                        diff = SageMakerJobMonitor.get_new_records(df_new=metrics_df, df_old=previous_metrics_df)
                         diff = metrics_df
                     elif not metrics_df.empty:  # First round
                         diff = metrics_df

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -15,10 +15,6 @@ try:
 except ImportError as ex:
     boto3 = DeferredImportException(ex)
 
-try:
-    import sagemaker
-except ImportError as ex:
-    sagemaker = DeferredImportException(ex)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -71,6 +67,8 @@ class SageMakerHelper:
         if not self.client:
             self._error_message = "Could not create boto client. Check your credentials"
             raise SageMakerNotAvailableException(self._error_message)
+
+        import sagemaker
 
         self.sagemaker_session = self.sagemaker_session or sagemaker.session.Session(sagemaker_client=self.client)
 

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -184,7 +184,9 @@ class SageMakerJobMonitor:
                 None, self.sagemaker_helper.wait_for_job_finish, job.name)
         try:
             job_status = await wait_for_finish_future
-        except Exception:  # pylint:disable=broad-except
+        except Exception as ex:  # pylint:disable=broad-except
+            if isinstance(ex, asyncio.CancelledError):
+                raise ex
             LOGGER.exception("Failed waiting for job to finish")
             job_status = self.sagemaker_helper.get_job_status(job_name=job)
         finally:

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -15,6 +15,12 @@ try:
 except ImportError as ex:
     boto3 = DeferredImportException(ex)
 
+try:
+    # Sagemaker Python SDK is optional
+    import sagemaker
+except ImportError as ex:
+    sagemaker = DeferredImportException(ex)
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,8 +73,6 @@ class SageMakerHelper:
         if not self.client:
             self._error_message = "Could not create boto client. Check your credentials"
             raise SageMakerNotAvailableException(self._error_message)
-
-        import sagemaker
 
         self.sagemaker_session = self.sagemaker_session or sagemaker.session.Session(sagemaker_client=self.client)
 

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -195,6 +195,7 @@ class SageMakerJobMonitor:
     def get_new_records(df_new: pd.DataFrame, df_old: Optional[pd.DataFrame] = None):
         """
         Return a list of new records
+        # TODO Verify this actually always works with sagemaker.analytics
         :param df_new: New dataframe, should have the same rows as `df_old` plus any new records
         :param df_old: Old dataframe, can be left None to return all records of the new DataFrame
         :return: List of dictionaries of the form {'column' -> 'value'}

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -36,13 +36,14 @@ class SageMakerHelper:
     def __init__(self, client=None, sagemaker_session=None):
         """
         Init SageMaker helper in the disabled state.
-        :param client: SageMaker client built with boto3.client("sagemaker") used for connecting to SageMaker
+        :param client: SageMaker client built with boto3.client("sagemaker") used for low-level connections to SM API
+        :param sagemaker_session: SageMaker Python SDK session
         """
         self.client = client
         self.connection_tried = False
         self.connection_succeeded = False
         self._error_message = None  # type: Optional[str]
-        self.sagemaker_session = None
+        self.sagemaker_session = sagemaker_session
 
     @property
     def __has_client(self):
@@ -69,7 +70,7 @@ class SageMakerHelper:
             self._error_message = "Could not create boto client. Check your credentials"
             raise SageMakerNotAvailableException(self._error_message)
 
-        self.sagemaker_session = sagemaker.session.Session(sagemaker_client=self.client)
+        self.sagemaker_session = self.sagemaker_session or sagemaker.session.Session(sagemaker_client=self.client)
 
         try:
             self.client.list_training_jobs()

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -219,7 +219,7 @@ class SageMakerJobMonitor:
                      job.name, sleep_time)
         previous_metrics_df = None
 
-        if not job.status.is_launched and self.notify_start:
+        if job.status.is_launched and self.notify_start:
             self.notify_start(job)
 
         try:

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -16,7 +16,7 @@ from .logger import remove_non_file_handlers
 from ..build import build_api
 
 LOGGER = logging.getLogger(__name__)
-DAEMON_BOOT_WAIT_TIME = 1.0  # In seconds
+DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
 
 
 # Do not expose anything by default (internal module)

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -114,8 +114,8 @@ class Service(object):
         if self.is_running():
             raise RuntimeError("Running already at {uri}".format(uri=self.uri))
         LOGGER.info("Starting service...")
-        proc = mp_ctx.Process(target=self.daemonize, args=[cloud_client_serialized])
         self.terminate_daemon = mp_ctx.Event()
+        proc = mp_ctx.Process(target=self.daemonize, args=[cloud_client_serialized])
         proc.daemon = True
         proc.start()
         proc.join()

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -114,8 +114,8 @@ class Service(object):
         if self.is_running():
             raise RuntimeError("Running already at {uri}".format(uri=self.uri))
         LOGGER.info("Starting service...")
-        self.terminate_daemon = mp_ctx.Event()
         proc = mp_ctx.Process(target=self.daemonize, args=[cloud_client_serialized])
+        self.terminate_daemon = mp_ctx.Event()
         proc.daemon = True
         proc.start()
         proc.join()

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -15,7 +15,7 @@ from .logger import remove_non_file_handlers
 from ..build import build_api
 
 LOGGER = logging.getLogger(__name__)
-DAEMON_BOOT_WAIT_TIME = 0.5  # In seconds
+DAEMON_BOOT_WAIT_TIME = 1.0  # In seconds
 
 
 # Do not expose anything by default (internal module)
@@ -99,7 +99,7 @@ class Service(object):
             finally:
                 loop.close()
             LOGGER.debug("Exiting service.")
-            time.sleep(1.0)  # Allows data scraping
+            time.sleep(2.0)  # Allows data scraping
 
         return
 

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -115,7 +115,7 @@ class Service(object):
             raise RuntimeError("Running already at {uri}".format(uri=self.uri))
         LOGGER.info("Starting service...")
         proc = mp_ctx.Process(target=self.daemonize, args=[cloud_client_serialized])
-        self.terminate_daemon = mp_ctx.Event()
+        self.terminate_daemon = mp_ctx.Event()  # TODO Is this 100% surely shared with the child process?
         proc.daemon = True
         proc.start()
         proc.join()

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 from functools import partial
 import logging
+import multiprocessing
 import os
 from typing import List
 import socket  # To verify daemon
@@ -66,6 +67,8 @@ class Service(object):
         pid = os.fork()
         if pid > 0:  # Close parent process
             return
+        if not self.terminate_daemon:
+            self.terminate_daemon = multiprocessing.get_context("spawn").Event()
         remove_non_file_handlers()
         os.setsid()  # Separate from tty
         cloud_client = dill.loads(serialized.encode('cp437'))
@@ -115,7 +118,6 @@ class Service(object):
             raise RuntimeError("Running already at {uri}".format(uri=self.uri))
         LOGGER.info("Starting service...")
         proc = mp_ctx.Process(target=self.daemonize, args=[cloud_client_serialized])
-        self.terminate_daemon = mp_ctx.Event()  # TODO Is this 100% surely shared with the child process?
         proc.daemon = True
         proc.start()
         proc.join()
@@ -126,7 +128,8 @@ class Service(object):
     def stop(self) -> bool:
         if self.is_running():
             if not self.terminate_daemon:
-                raise RuntimeError("Terminate daemon event does not exist.")
+                raise RuntimeError("Terminate daemon event does not exist. "
+                                   "The stop() method may have called from the wrong process.")
             self.terminate_daemon.set()  # Flag for requestLoop to terminate
             with Pyro4.Proxy(self.uri) as pyro_proxy:
                 # triggers checking loopCondition

--- a/meeshkan/exceptions.py
+++ b/meeshkan/exceptions.py
@@ -43,3 +43,8 @@ class DeferredImportException:
 
     def __getattr__(self, name):
         raise self.exception
+
+
+class AgentNotAvailableException(Exception):
+    def __index__(self):
+        super().__init__("Start the agent first.")

--- a/meeshkan/notifications/notifiers.py
+++ b/meeshkan/notifications/notifiers.py
@@ -50,6 +50,7 @@ class Notifier(object):
             notification = NotificationWithStatusTime(NotificationType.JOB_START, NotificationStatus.SUCCESS)
             self.__add_to_history(job.id, notification)
         except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Notifying job start failed")
             notification = NotificationWithStatusTime(NotificationType.JOB_START, NotificationStatus.FAILED)
             self.__add_to_history(job.id, notification)
 
@@ -59,7 +60,7 @@ class Notifier(object):
             notification = NotificationWithStatusTime(NotificationType.JOB_END, NotificationStatus.SUCCESS)
             self.__add_to_history(job.id, notification)
         except Exception as ex:  # pylint: disable=broad-except
-            LOGGER.exception(ex)
+            LOGGER.exception("Notifying job end failed")
             notification = NotificationWithStatusTime(NotificationType.JOB_END, NotificationStatus.FAILED)
             self.__add_to_history(job.id, notification)
 
@@ -69,6 +70,7 @@ class Notifier(object):
             notification = NotificationWithStatusTime(NotificationType.JOB_UPDATE, NotificationStatus.SUCCESS)
             self.__add_to_history(job.id, notification)
         except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Notifying job update failed")
             notification = NotificationWithStatusTime(NotificationType.JOB_UPDATE, NotificationStatus.FAILED)
             self.__add_to_history(job.id, notification)
 

--- a/meeshkan/utils.py
+++ b/meeshkan/utils.py
@@ -12,6 +12,7 @@ import meeshkan
 from .core.cloud import CloudClient
 from .core.service import Service
 from .core.api import Api
+from .exceptions import AgentNotAvailableException
 
 __all__ = ["save_token"]
 
@@ -32,7 +33,7 @@ def _get_api() -> Api:
     service = Service()
     if not service.is_running():
         print("Start the service first.")
-        sys.exit(1)
+        raise AgentNotAvailableException()
     api = service.api  # type: Api
     return api
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@ SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 # Older version of requests because >= 2.21 conflicts with sagemaker.
 REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
 
-DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sphinx',
+DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sagemaker', 'sphinx',
        'sphinx_rtd_theme']
+
 # Optional packages
 EXTRAS = {'dev': DEV,
           'devTF': DEV + ['tensorflow', 'tensorboard', 'keras'],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 # Older version of requests because >= 2.21 conflicts with sagemaker.
 REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
 
-DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sagemaker', 'sphinx',
+DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sphinx',
        'sphinx_rtd_theme']
 
 # Optional packages

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 # Older version of requests because >= 2.21 conflicts with sagemaker.
 REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
 
-DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sphinx',
+DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sagemaker', 'sphinx',
        'sphinx_rtd_theme']
 
 # Optional packages

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -23,13 +23,11 @@ def service():
     yield service_
 
 
-# @pytest.mark.skip
 def test_start_stop(service, mock_cloud_client):
     service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
     assert service.stop(), "Service should be able to stop cleanly after the service is already running!"
 
 
-# @pytest.mark.skip
 def test_double_start(service, mock_cloud_client):
     service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
     with pytest.raises(RuntimeError):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,15 +18,18 @@ def mock_cloud_client():
 def service():
     service_ = Service()
     if service_.is_running():
-        service_.stop()
+        with service.api as api:
+            api.stop()
     yield service_
 
 
+# @pytest.mark.skip
 def test_start_stop(service, mock_cloud_client):
     service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
     assert service.stop(), "Service should be able to stop cleanly after the service is already running!"
 
 
+# @pytest.mark.skip
 def test_double_start(service, mock_cloud_client):
     service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
     with pytest.raises(RuntimeError):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,7 +18,7 @@ def mock_cloud_client():
 def service():
     service_ = Service()
     if service_.is_running():
-        with service_.api() as api:
+        with service_.api as api:
             api.stop()
     yield service_
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,7 +18,7 @@ def mock_cloud_client():
 def service():
     service_ = Service()
     if service_.is_running():
-        with service.api as api:
+        with service.api() as api:
             api.stop()
     yield service_
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -14,22 +14,31 @@ def mock_cloud_client():
     return PicklableMock()
 
 
-@pytest.fixture
-def service():
-    service_ = Service()
+def stop_if_running(service_):
     if service_.is_running():
         with service_.api as api:
             api.stop()
+
+
+@pytest.fixture
+def service():
+    service_ = Service()
+    stop_if_running(service_)
     yield service_
+    stop_if_running(service_)
 
 
-def test_start_stop(service, mock_cloud_client):
+def test_start_stop(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
     service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
-    assert service.stop(), "Service should be able to stop cleanly after the service is already running!"
+    assert service.is_running()
+    stop_if_running(service_=service)
+    assert not service.is_running()
 
 
-def test_double_start(service, mock_cloud_client):
+def test_double_start(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
     service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+    assert service.is_running()
     with pytest.raises(RuntimeError):
         service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
-    service.stop()
+    stop_if_running(service_=service)
+    assert not service.is_running()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,7 +18,7 @@ def mock_cloud_client():
 def service():
     service_ = Service()
     if service_.is_running():
-        with service.api() as api:
+        with service_.api() as api:
             api.stop()
     yield service_
 

--- a/tests/test_sagemaker_monitor.py
+++ b/tests/test_sagemaker_monitor.py
@@ -31,7 +31,6 @@ def training_job_description_for_status(status):
     }
 
 
-@pytest.mark.skip
 class TestSageMakerHelper:
 
     def test_get_job_status(self, mock_boto, mock_sagemaker_session):
@@ -90,7 +89,6 @@ def sagemaker_job_monitor(event_loop, mock_sagemaker_helper):
                                notify_finish=MagicMock())
 
 
-@pytest.mark.skip
 class TestSageMakerJobMonitor:
 
     def test_create_queued_job(self, sagemaker_job_monitor: SageMakerJobMonitor):

--- a/tests/test_sagemaker_monitor.py
+++ b/tests/test_sagemaker_monitor.py
@@ -31,6 +31,7 @@ def training_job_description_for_status(status):
     }
 
 
+@pytest.mark.skip
 class TestSageMakerHelper:
 
     def test_get_job_status(self, mock_boto, mock_sagemaker_session):
@@ -89,6 +90,7 @@ def sagemaker_job_monitor(event_loop, mock_sagemaker_helper):
                                notify_finish=MagicMock())
 
 
+@pytest.mark.skip
 class TestSageMakerJobMonitor:
 
     def test_create_queued_job(self, sagemaker_job_monitor: SageMakerJobMonitor):

--- a/tests/test_sagemaker_monitor.py
+++ b/tests/test_sagemaker_monitor.py
@@ -2,6 +2,7 @@
 import asyncio
 from unittest.mock import create_autospec, MagicMock
 
+import pandas as pd
 import pytest
 
 from meeshkan.core.job import JobStatus
@@ -108,6 +109,25 @@ class TestSageMakerJobMonitor:
         await asyncio.wait_for(monitoring_task, timeout=1)  # Should finish
         sagemaker_job_monitor.sagemaker_helper.wait_for_job_finish.assert_called_once()
         sagemaker_job_monitor.notify_finish.assert_called_with(job)
+
+    def test_compute_df_diff_for_no_changes(self):
+        df_old = pd.DataFrame.from_dict({'timestamp': [1, 2], 'metric_name': ['epoch', 'loss'], 'value': [1, 3.2]})
+        df_new = df_old.copy()
+        df_diff = SageMakerJobMonitor.get_new_records(df_new=df_new, df_old=df_old)
+        assert len(df_diff) == 0
+
+    def test_compute_df_diff_for_new_row(self):
+        df_old = pd.DataFrame.from_dict({'timestamp': [1, 2], 'metric_name': ['epoch', 'loss'], 'value': [1, 3.2]})
+        new_row = {'timestamp': 3, 'metric_name': 'loss', 'value': 2.3}
+        df_new = df_old.copy().append(new_row, ignore_index=True)
+        assert len(df_old) == 2
+        assert len(df_new) == 3
+        df_diff = SageMakerJobMonitor.get_new_records(df_new=df_new, df_old=df_old)
+        assert len(df_diff) == 1
+        row = df_diff[0]
+        assert row['timestamp'] == new_row['timestamp']
+        assert row['metric_name'] == new_row['metric_name']
+        assert row['value'] == new_row['value']
 
 
 def sagemaker_available():


### PR DESCRIPTION
Sorry for the huge PR, it took quite some effort to get stuff working.
- Fetch job metrics using [sagemaker.analytics](https://sagemaker.readthedocs.io/en/latest/analytics.html)
- Compute the difference of records in previous and new metrics, assuming that `sagemaker.analytics` appends new rows to the end of DataFrame once new values emerge. **This should be checked**
- Add new scalars to the job via `job.add_scalar`
- Notify updates via the same notify method as for scheduler jobs
- Update example notebook to use a cheaper instance (takes three hours to train now), add some new metrics to be outputted by the script (learning rate and training loss)
- Copy-paste code from `Scheduler` for querying and posting job metrics, these should probably go to `TrackerBase` or `JobMonitorBase` to avoid duplicating code
- Use `threading.Lock` in initializing `SageMakerHelper` connections to avoid race conditions
- Minimum polling interval of 60 secs in `SageMakerJobMonitor`. It only notifies when new values are available, though.
- Change `meeshkan stop` to not raise an exception when used before starting the agent
- Create `terminate_daemon` event in the daemon process, this should be more robust than setting it before spawning and forking (?)
- [x]  Something's broken in Azure tests, I could also reproduce this locally at some point... EDIT: Added longer waiting times and changed `maxParallel` to one. Also changed `terminate_daemon` to be created in the API process. The process can only be stopped via the Pyro proxy anyway in real usage, as only tests re-use the `Service` instance for `start` -> `stop` etc.