### PR TITLE
Clean `meeshkan` library

### DIFF
--- a/meeshkan/__build__.py
+++ b/meeshkan/__build__.py
@@ -2,7 +2,7 @@
 Build the whole dependency chain leading to Api instance exposed by Pyro.
 """
 
-__all__ = []
+__all__ = []  # type: ignore
 
 
 def _build_api(service, cloud_client):

--- a/meeshkan/__build__.py
+++ b/meeshkan/__build__.py
@@ -1,10 +1,11 @@
 """
-Builder for the agent API, defining (almost) the whole dependency chain.
+Build the whole dependency chain leading to Api instance exposed by Pyro.
 """
-__all__ = ["build_api"]
+
+__all__ = []
 
 
-def build_api(service, cloud_client):
+def _build_api(service, cloud_client):
     from meeshkan.core.api import Api
     from meeshkan.notifications.notifiers import CloudNotifier, LoggingNotifier, NotifierCollection
     from meeshkan.core.tasks import TaskPoller

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -9,7 +9,7 @@ from . import sagemaker
 from . import notifications  # Exposed for tests for now
 from . import build  # Deleted below
 from .start import start_agent as start, restart_agent as restart, init, stop_agent as stop
-from .utils import save_token
+from .__utils__ import save_token
 
 # Only make the following available by default
 __all__ = ["__version__", "exceptions", "config"]

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -17,7 +17,6 @@ __all__ += ["save_token", "start", "restart_agent", "init"]
 
 del core  # Clean-up (make `meeshkan.core` unavailable)
 del api
-# del utils  # This is still required by tests that use patching.
 
 __doc__ = """
 Meeshkan - Monitoring and remote-control tool for machine learning jobs

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -7,7 +7,6 @@ from . import api
 from . import exceptions
 from . import sagemaker
 from . import notifications  # Exposed for tests for now
-from . import build  # Deleted below
 from .start import start_agent as start, restart_agent as restart, init, stop_agent as stop
 from .__utils__ import save_token
 
@@ -18,7 +17,6 @@ __all__ += ["save_token", "start", "restart_agent", "init"]
 
 del core  # Clean-up (make `meeshkan.core` unavailable)
 del api
-del build
 # del utils  # This is still required by tests that use patching.
 
 __doc__ = """

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -6,6 +6,8 @@ from .api import *  # pylint: disable=wildcard-import
 from . import api
 from . import exceptions
 from . import sagemaker
+from . import notifications  # Exposed for tests for now
+from . import build  # Deleted below
 from .start import start_agent as start, restart_agent as restart, init, stop_agent as stop
 from .utils import save_token
 
@@ -16,7 +18,8 @@ __all__ += ["save_token", "start", "restart_agent", "init"]
 
 del core  # Clean-up (make `meeshkan.core` unavailable)
 del api
-# del utils  # This is still required by mocking tests
+del build
+# del utils  # This is still required by tests that use patching.
 
 __doc__ = """
 Meeshkan - Monitoring and remote-control tool for machine learning jobs

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -26,7 +26,7 @@ from .core.api import Api
 from .core.service import Service
 from .core.logger import setup_logging, remove_non_file_handlers
 from .core.job import Job
-from .utils import save_token, get_auth, _get_api, _build_cloud_client
+from .__utils__ import save_token, get_auth, _get_api, _build_cloud_client
 from .start import start_agent
 
 LOGGER = None

--- a/meeshkan/__utils__.py
+++ b/meeshkan/__utils__.py
@@ -3,7 +3,6 @@
 #     examples for such errors: "error: Name 'meeshkan.config.Configuration' is not defined",
 #                               "error: Module has no attribute "config"
 
-import sys
 import logging
 
 from typing import Tuple

--- a/meeshkan/api/__init__.py
+++ b/meeshkan/api/__init__.py
@@ -6,9 +6,6 @@ from . import scalars
 from .scalars import *  # pylint: disable=wildcard-import
 from . import utils
 from .utils import *  # pylint: disable=wildcard-import
-from ..sagemaker import monitor as monitor_sagemaker
-
 
 __all__ = scalars.__all__
 __all__ += conditions.__all__
-__all__ += ["monitor_sagemaker"]

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -13,7 +13,7 @@ import dill
 import Pyro4  # For daemon management
 
 from .logger import remove_non_file_handlers
-from ..build import build_api
+from ..__build__ import _build_api
 
 LOGGER = logging.getLogger(__name__)
 DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
@@ -75,7 +75,7 @@ class Service(object):
         Pyro4.config.SERIALIZER = 'dill'
         Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
         Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
-        with build_api(self, cloud_client=cloud_client) as api, Pyro4.Daemon(host=self.host, port=self.port) as daemon:
+        with _build_api(self, cloud_client=cloud_client) as api, Pyro4.Daemon(host=self.host, port=self.port) as daemon:
             daemon.register(api, Service.OBJ_NAME)  # Register the API with the daemon
 
             async def start_daemon_and_polling_loops():

--- a/meeshkan/start.py
+++ b/meeshkan/start.py
@@ -8,7 +8,6 @@ import requests
 import Pyro4
 
 from . import __utils__
-from .__utils__ import get_auth, _get_api
 from .core.config import init_config, ensure_base_dirs
 from .core.service import Service
 from .__version__ import __version__
@@ -45,7 +44,7 @@ def __verify_version():
 def init(token: Optional[str] = None):
     ensure_base_dirs()
     try:
-        _, credentials = get_auth()
+        _, credentials = __utils__.get_auth()
     except FileNotFoundError:
         # Credentials not found
         credentials = None
@@ -62,7 +61,7 @@ def init(token: Optional[str] = None):
 def _stop_if_running() -> bool:
     if Service().is_running():
         print("Stopping service...")
-        api = _get_api()
+        api = __utils__._get_api()
         api.stop()
         return True
     return False
@@ -93,7 +92,7 @@ def start_agent() -> str:
         print("Service is already running.")
         return service.uri
 
-    config, credentials = get_auth()
+    config, credentials = __utils__.get_auth()
 
     cloud_client = __utils__._build_cloud_client(config, credentials)
     cloud_client.notify_service_start()

--- a/meeshkan/start.py
+++ b/meeshkan/start.py
@@ -9,7 +9,7 @@ import Pyro4
 
 from . import __utils__
 from .__utils__ import get_auth, _get_api
-from .core.config import init_config
+from .core.config import init_config, ensure_base_dirs
 from .core.service import Service
 from .__version__ import __version__
 
@@ -43,6 +43,7 @@ def __verify_version():
 
 
 def init(token: Optional[str] = None):
+    ensure_base_dirs()
     try:
         _, credentials = get_auth()
     except FileNotFoundError:

--- a/meeshkan/start.py
+++ b/meeshkan/start.py
@@ -7,8 +7,8 @@ import dill
 import requests
 import Pyro4
 
-from . import utils
-from .utils import get_auth, _get_api
+from . import __utils__
+from .__utils__ import get_auth, _get_api
 from .core.config import init_config
 from .core.service import Service
 from .__version__ import __version__
@@ -52,7 +52,7 @@ def init(token: Optional[str] = None):
     # Only save supplied token if it's not the same as that included already
     if token and (not credentials or credentials.refresh_token != token):
         print("Stored credentials.")
-        utils.save_token(token)
+        __utils__.save_token(token)
         init_config(force_refresh=True)
 
     restart_agent()
@@ -94,7 +94,7 @@ def start_agent() -> str:
 
     config, credentials = get_auth()
 
-    cloud_client = utils._build_cloud_client(config, credentials)
+    cloud_client = __utils__._build_cloud_client(config, credentials)
     cloud_client.notify_service_start()
     cloud_client_serialized = dill.dumps(cloud_client, recurse=True).decode('cp437')
     pyro_uri = service.start(mp.get_context("spawn"), cloud_client_serialized=cloud_client_serialized)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ from .utils import MockResponse, DummyStore, PicklableMock
 CLI_RUNNER = CliRunner()
 
 
-BUILD_CLOUD_CLIENT_PATCH_PATH = 'meeshkan.utils._build_cloud_client'
+BUILD_CLOUD_CLIENT_PATCH_PATH = 'meeshkan.__utils__._build_cloud_client'
 
 
 def run_cli(args, inputs=None, catch_exceptions=True):


### PR DESCRIPTION
- Quick clean-up of library exposed methods for 0.1.4, I think more clean-up can be done for the next version then
- Delete `meeshkan.monitor_sagemaker`, use `meeshkan.sagemaker.monitor` instead
- Rename `build.py` as `__build__.py` and `utils.py` to `__utils__.py` to "hide" them from `meeshkan`
- I did not include `_build_api` in `__utils__` as I felt it's a  tad cleaner to have the building of the dependency chain in a module of its own and not have he build module to depend on other imports needed by other methods in `__utils__`
- [ ]  `start.py` will need to be refactored at some point, I'd rather not start doing that now as `meeshkan.start()` is anyway referring to `start_agent()` and the module