### PR TITLE
Fix documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'sphinx_click.ext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,18 +3,6 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Meeshkan - Monitoring and remote-control tool for machine learning jobs
-=======================================================================
-**meeshkan** is a Python package providing control to your machine learning jobs.
-
-Main Features
--------------
-Here are just a few of the things meeshkan can do:
-  - Notify you of your job's progress at fixed intervals.
-  - Notify you when certain events happen
-  - Allow you to control training jobs remotely
-  - Allow monitoring Amazon SageMaker jobs
-
 
 .. automodule:: meeshkan
    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,20 +1,25 @@
-.. Meeshkan documentation master file, created by
-   sphinx-quickstart on Thu Nov 22 14:20:05 2018.
+.. meeshkan documentation master file, created by
+   sphinx-quickstart on Mon Jan 14 12:44:49 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Meeshkan's documentation!
-====================================
+Meeshkan - Monitoring and remote-control tool for machine learning jobs
+=======================================================================
+**meeshkan** is a Python package providing control to your machine learning jobs.
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+Main Features
+-------------
+Here are just a few of the things meeshkan can do:
+  - Notify you of your job's progress at fixed intervals.
+  - Notify you when certain events happen
+  - Allow you to control training jobs remotely
+  - Allow monitoring Amazon SageMaker jobs
 
 
+.. automodule:: meeshkan
+   :members:
+   :undoc-members:
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+.. automodule:: meeshkan.sagemaker
+   :members:
+   :undoc-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,20 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+Meeshkan - Monitoring and remote-control tool for machine learning jobs
+=======================================================================
+**meeshkan** is a Python package providing control to your machine learning jobs.
+
+Main Features
+-------------
+Here are just a few of the things meeshkan can do:
+  - Notify you of your job's progress at fixed intervals.
+  - Notify you when certain events happen
+  - Allow you to control training jobs remotely
+  - Allow monitoring Amazon SageMaker jobs
+
+Usage as Python library
+=======================
 
 .. automodule:: meeshkan
    :members:
@@ -11,3 +25,10 @@
 .. automodule:: meeshkan.sagemaker
    :members:
    :undoc-members:
+
+Command-line interface
+======================
+
+.. click:: meeshkan.__main__:cli
+   :prog: meeshkan
+   :show-nested:

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -20,7 +20,7 @@ del api
 
 __doc__ = """
 Meeshkan - Monitoring and remote-control tool for machine learning jobs
-=====================================================================
+=======================================================================
 **meeshkan** is a Python package providing control to your machine learning jobs. 
 
 Main Features

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -6,17 +6,19 @@ from .api import *  # pylint: disable=wildcard-import
 from . import api
 from . import exceptions
 from . import sagemaker
-from . import notifications  # Exposed for tests for now
-from .start import start_agent as start, restart_agent as restart, init, stop_agent as stop
 from .__utils__ import save_token
+from . import agent
+from .agent import *
+
 
 # Only make the following available by default
 __all__ = ["__version__", "exceptions", "config"]
 __all__ += api.__all__
-__all__ += ["save_token", "start", "restart_agent", "init"]
+__all__ += agent.__all__
 
 del core  # Clean-up (make `meeshkan.core` unavailable)
 del api
+del agent
 
 __doc__ = """
 Meeshkan - Monitoring and remote-control tool for machine learning jobs

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -19,17 +19,3 @@ __all__ += agent.__all__
 del core  # Clean-up (make `meeshkan.core` unavailable)
 del api
 del agent
-
-__doc__ = """
-Meeshkan - Monitoring and remote-control tool for machine learning jobs
-=======================================================================
-**meeshkan** is a Python package providing control to your machine learning jobs. 
-
-Main Features
--------------
-Here are just a few of the things meeshkan can do:
-  - Notify you of your job's progress at fixed intervals.
-  - Notify you when certain events happen
-  - Allow you to control training jobs remotely
-  - Allow monitoring Amazon SageMaker jobs
-"""

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -39,6 +39,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option("--debug", is_flag=True)
 @click.option("--silent", is_flag=True)
 def cli(debug, silent):
+    """Command-line interface for working with the Meeshkan agent."""
     if not debug:
         sys.tracebacklimit = 0
 

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -27,7 +27,7 @@ from .core.service import Service
 from .core.logger import setup_logging, remove_non_file_handlers
 from .core.job import Job
 from .__utils__ import save_token, get_auth, _get_api, _build_cloud_client
-from .start import start_agent
+from .agent import start as start_agent
 
 LOGGER = None
 

--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -18,7 +18,7 @@ Pyro4.config.SERIALIZER = 'dill'
 Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
 Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 
-__all__ = ["start_agent", "init", "stop_agent", "restart_agent"]
+__all__ = ["start", "init", "stop", "restart"]
 
 
 def __verify_version():
@@ -42,6 +42,10 @@ def __verify_version():
 
 
 def init(token: Optional[str] = None):
+    """Initialize the Meeshkan agent, optionally with the provided credentials.
+
+    :param token: Meeshkan service token. Only required if credentials have not been setup before.
+    """
     ensure_base_dirs()
     try:
         _, credentials = __utils__.get_auth()
@@ -55,7 +59,7 @@ def init(token: Optional[str] = None):
         __utils__.save_token(token)
         init_config(force_refresh=True)
 
-    restart_agent()
+    restart()
 
 
 def _stop_if_running() -> bool:
@@ -67,7 +71,9 @@ def _stop_if_running() -> bool:
     return False
 
 
-def stop_agent():
+def stop():
+    """Stop the agent.
+    """
     was_running = _stop_if_running()
     if was_running:
         print("Service stopped.")
@@ -75,16 +81,18 @@ def stop_agent():
         print("Service already stopped.")
 
 
-def restart_agent():
+def restart():
+    """Restart the agent.
+    """
     _stop_if_running()
     init_config(force_refresh=True)
-    start_agent()
+    start()
 
 
-def start_agent() -> str:
-    """
-    Starts the agent.
-    :raises UnauthorizedException: If credentials have not been setup.
+def start() -> str:
+    """Start the agent.
+
+    :return str: Pyro server URI.
     """
     __verify_version()
     service = Service()

--- a/meeshkan/sagemaker/lib.py
+++ b/meeshkan/sagemaker/lib.py
@@ -10,7 +10,8 @@ Pyro4.config.SERIALIZER = 'dill'
 
 def monitor(job_name: str, poll_interval: Optional[float] = None):
     """
-    Start monitoring a SageMaker training job
+    Start monitoring a SageMaker training job.
+
     :param job_name: SageMaker training job name
     :param poll_interval: Polling interval in seconds, optional. Defaults to one hour.
     :return: SageMakerJob instance

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
 
 DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sagemaker', 'sphinx',
-       'sphinx_rtd_theme']
+       'sphinx-click', 'sphinx_rtd_theme']
 
 # Optional packages
 EXTRAS = {'dev': DEV,


### PR DESCRIPTION
- Update `index.rst` to show the library commands
- Rename `start.py` as `agent.py` to avoid confusion between the method `meeshkan.start` and the module `meeshkan.start`
- [x]  Include docs for the CLI, using [sphinx-click](https://github.com/click-contrib/sphinx-click)
- Now looks like this when generated locally with `python setup.py doc`:
![screenshot 2019-01-14 at 13 58 10](https://user-images.githubusercontent.com/11660974/51111350-79911d80-1804-11e9-84a0-3c1c096404df.png)
- Thanks Idan for finding the `automodule` thing!