### PR TITLE
Only track training loss, use ml.p2.xlarge in the example notebook, hold reference to TrainingJobAnalytics object.

### DIFF
--- a/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
+++ b/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
@@ -258,8 +258,6 @@
    "outputs": [],
    "source": [
     "float_pattern = \"([0-9\\\\.]+)\"\n",
-    "epoch_pattern = \"Epoch={}\".format(float_pattern)\n",
-    "val_loss_pattern = \"ValidationLoss={}\".format(float_pattern)\n",
     "training_loss_pattern = \"TrainingLoss={}\".format(float_pattern)"
    ]
   },
@@ -282,15 +280,13 @@
     "                    role=role,\n",
     "                    framework_version='1.0.0',\n",
     "                    train_instance_count=1,\n",
-    "                    train_instance_type='ml.m4.xlarge',  # Use e.g. `ml.p2.xlarge` to train faster\n",
+    "                    train_instance_type='ml.p2.xlarge',\n",
     "                    source_dir='source',\n",
     "                    hyperparameters={\n",
     "                        'epochs': 2,\n",
     "                        'tied': True\n",
     "                    },\n",
     "                    metric_definitions=[\n",
-    "                        {'Name': 'epoch', 'Regex': epoch_pattern},\n",
-    "                        {'Name': 'val:loss', 'Regex': val_loss_pattern},\n",
     "                        {'Name': 'train:loss', 'Regex': training_loss_pattern}\n",
     "                    ]\n",
     "                   )"

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -253,6 +253,7 @@ class SageMakerJobMonitor:
                         None,
                         self.sagemaker_helper.get_training_job_analytics_df, job.name)
                     if not metrics_df.empty:
+                        metrics_df = metrics_df.sort_values(by="timestamp")
                         new_records = SageMakerJobMonitor.get_new_records(df_new=metrics_df, df_old=previous_metrics_df)
                         previous_metrics_df = metrics_df
                     else:

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -256,7 +256,9 @@ class SageMakerJobMonitor:
                         None,
                         self.sagemaker_helper.get_training_job_analytics_df, job.name)
                     if not metrics_df.empty:
-                        metrics_df = metrics_df.sort_values(by="timestamp")
+                        # TODO Fix the bug where new metrics are prepended in the dataframe
+                        # and incorrectly handled by the `get_new_records`. Look `TrackerBase` for example.
+                        # LOGGER.debug("Got metrics df: %s", metrics_df)
                         new_records = SageMakerJobMonitor.get_new_records(df_new=metrics_df, df_old=previous_metrics_df)
                         previous_metrics_df = metrics_df
                     else:

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -1,6 +1,6 @@
 """Watch a running SageMaker job."""
 import asyncio
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import logging
 import os
 import threading
@@ -50,6 +50,7 @@ class SageMakerHelper:
         self._error_message = None  # type: Optional[str]
         self.sagemaker_session = sagemaker_session
         self.lock = threading.Lock()
+        self.analytics_by_job_name = {}  # type: Dict[str, sagemaker.analytics.TrainingJobAnalytics]
 
     @property
     def __has_client(self):
@@ -151,8 +152,10 @@ class SageMakerHelper:
             self.check_or_build_connection()
 
         LOGGER.debug("Checking for updates for job %s", job_name)
-        analytics = sagemaker.analytics.TrainingJobAnalytics(training_job_name=job_name,
-                                                             sagemaker_session=self.sagemaker_session)
+        analytics = self.analytics_by_job_name.setdefault(job_name,
+                                                          sagemaker.analytics.TrainingJobAnalytics(
+                                                              training_job_name=job_name,
+                                                              sagemaker_session=self.sagemaker_session))
         return analytics.dataframe(force_refresh=True)
 
 


### PR DESCRIPTION
- I assumed that `sagemaker.analytics.TrainingJobAnalytics(training_job_name=...)` would return a monotonically growing dataframe that would have metrics in a monotonously increasing order. This is not true: at any step new rows can be prepended to the existing ones with earlier timestamps. Not sure how this all works but the current example does not work. I'll try and fix that soon but this fixes the example.
- Hold a reference to TrainingJobAnalytics by job name to avoid re-creating it every time.