### PR TITLE
Do not install dev requirements in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Install dependencies using setup.py
--e .[dev]
+-e .


### PR DESCRIPTION
ReadTheDocs currently uses requirements.txt to install dependencies, the sphinx dependencies conflict with its own. I don't think requirements.txt needs to include the dev dependencies anyway.