### PR TITLE
Fix scalar tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ tests/resources/logs
 
 # MyPy
 .mypy_cache/
+
+.DS_Store

--- a/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
+++ b/examples/sagemaker/pytorch_rnn_meeshkan.ipynb
@@ -258,7 +258,8 @@
    "outputs": [],
    "source": [
     "float_pattern = \"([0-9\\\\.]+)\"\n",
-    "training_loss_pattern = \"TrainingLoss={}\".format(float_pattern)"
+    "training_loss_pattern = \"TrainingLoss={}\".format(float_pattern)\n",
+    "validation_loss_pattern = \"ValidationLoss={}\".format(float_pattern)"
    ]
   },
   {
@@ -287,7 +288,8 @@
     "                        'tied': True\n",
     "                    },\n",
     "                    metric_definitions=[\n",
-    "                        {'Name': 'train:loss', 'Regex': training_loss_pattern}\n",
+    "                        {'Name': 'train:loss', 'Regex': training_loss_pattern},\n",
+    "                        {'Name': 'validation:loss', 'Regex': validation_loss_pattern}\n",
     "                    ]\n",
     "                   )"
    ]

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -180,10 +180,10 @@ class JobScalarHelper:
 
         for metric_name, metrics_for_name in metrics_grouped_by_name:
             max_timestamp_for_name = metrics_for_name["timestamp"].max()
-            previous_last_timestamp_or_none = self.last_timestamp_by_metric.get(metric_name, None)
-            # Filter DataFrame by timestamp if previous not None
-            new_records_df = metrics_for_name[metrics_for_name.timestamp > previous_last_timestamp_or_none] \
-                if previous_last_timestamp_or_none is not None else metrics_for_name
+            previous_last_timestamp_or_none = self.last_timestamp_by_metric.get(metric_name, float("-inf"))
+
+            new_records_df = metrics_for_name[metrics_for_name.timestamp > previous_last_timestamp_or_none]
+
             for _, record in new_records_df.iterrows():
                 added_new_metrics = True
                 self.job.add_scalar_to_history(scalar_name=record['metric_name'], scalar_value=record['value'])

--- a/meeshkan/core/sagemaker_monitor.py
+++ b/meeshkan/core/sagemaker_monitor.py
@@ -240,24 +240,6 @@ class SageMakerJobMonitor:
             LOGGER.info("Notifying finish for job %s with status %s", job.name, job.status)
             self.notify_finish(job)
 
-    @staticmethod
-    def get_new_records(df_new: pd.DataFrame, df_old: Optional[pd.DataFrame] = None):
-        """
-        Return a list of new records
-        # TODO Verify this actually always works with sagemaker.analytics
-        :param df_new: New dataframe, should have the same rows as `df_old` plus any new records
-        :param df_old: Old dataframe, can be left None to return all records of the new DataFrame
-        :return: List of dictionaries of the form {'column' -> 'value'}
-        """
-        if df_old is None or df_old.empty:
-            return df_new.to_dict(orient='records')
-
-        if df_new.empty:
-            return []
-
-        assert len(df_new) >= len(df_old)
-        return df_new.loc[len(df_old):len(df_new)].to_dict(orient='records')
-
     async def poll_updates(self, job: BaseJob):
         if not isinstance(job, SageMakerJob):
             raise RuntimeError("SageMakerJobMonitor can only monitor SageMakerJobs.")

--- a/tests/test_sagemaker_monitor.py
+++ b/tests/test_sagemaker_monitor.py
@@ -132,25 +132,6 @@ class TestSageMakerJobMonitor:
         sagemaker_job_monitor.sagemaker_helper.wait_for_job_finish.assert_called_once()
         sagemaker_job_monitor.notify_finish.assert_called_with(job)
 
-    def test_compute_df_diff_for_no_changes(self):
-        df_old = pd.DataFrame.from_dict({'timestamp': [1, 2], 'metric_name': ['epoch', 'loss'], 'value': [1, 3.2]})
-        df_new = df_old.copy()
-        df_diff = SageMakerJobMonitor.get_new_records(df_new=df_new, df_old=df_old)
-        assert len(df_diff) == 0
-
-    def test_compute_df_diff_for_new_row(self):
-        df_old = pd.DataFrame.from_dict({'timestamp': [1, 2], 'metric_name': ['epoch', 'loss'], 'value': [1, 3.2]})
-        new_row = {'timestamp': 3, 'metric_name': 'loss', 'value': 2.3}
-        df_new = df_old.copy().append(new_row, ignore_index=True)
-        assert len(df_old) == 2
-        assert len(df_new) == 3
-        df_diff = SageMakerJobMonitor.get_new_records(df_new=df_new, df_old=df_old)
-        assert len(df_diff) == 1
-        row = df_diff[0]
-        assert row['timestamp'] == new_row['timestamp']
-        assert row['metric_name'] == new_row['metric_name']
-        assert row['value'] == new_row['value']
-
 
 @pytest.fixture
 def example_sm_record():

--- a/tests/test_sagemaker_monitor.py
+++ b/tests/test_sagemaker_monitor.py
@@ -134,11 +134,6 @@ class TestSageMakerJobMonitor:
 
 
 @pytest.fixture
-def example_sm_record():
-    return {'metric_name': 'train_loss', 'value': 2.3, 'timestamp': 0.0}
-
-
-@pytest.fixture
 def sagemaker_job(sagemaker_job_monitor):
     job_name = "spameggs"
     return sagemaker_job_monitor.create_job(job_name=job_name)
@@ -151,65 +146,67 @@ def job_scalar_helper():
 
 class TestJobScalarHelper:
 
-    def test_adding_new_metric(self, example_sm_record, job_scalar_helper):
-        dataframe = pd.DataFrame.from_dict([example_sm_record])
+    EXAMPLE_SM_RECORD = {'metric_name': 'train_loss', 'value': 2.3, 'timestamp': 0.0}
+
+    def test_adding_new_metric(self, job_scalar_helper):
+        dataframe = pd.DataFrame.from_dict([TestJobScalarHelper.EXAMPLE_SM_RECORD])
         sagemaker_job = job_scalar_helper.job
         job_scalar_helper.add_new_scalars_from(dataframe)
         sagemaker_job.add_scalar_to_history.assert_called_once_with(
-            scalar_name=example_sm_record['metric_name'],
-            scalar_value=example_sm_record['value'])
+            scalar_name=TestJobScalarHelper.EXAMPLE_SM_RECORD['metric_name'],
+            scalar_value=TestJobScalarHelper.EXAMPLE_SM_RECORD['value'])
 
-    def test_adding_same_metric_twice(self, example_sm_record, job_scalar_helper):
-        dataframe = pd.DataFrame.from_dict([example_sm_record])
+    def test_adding_same_metric_twice(self, job_scalar_helper):
+        dataframe = pd.DataFrame.from_dict([TestJobScalarHelper.EXAMPLE_SM_RECORD])
         sagemaker_job = job_scalar_helper.job
         job_scalar_helper.add_new_scalars_from(dataframe)
         job_scalar_helper.add_new_scalars_from(dataframe)
         sagemaker_job.add_scalar_to_history.assert_called_once_with(
-            scalar_name=example_sm_record['metric_name'],
-            scalar_value=example_sm_record['value'])
+            scalar_name=TestJobScalarHelper.EXAMPLE_SM_RECORD['metric_name'],
+            scalar_value=TestJobScalarHelper.EXAMPLE_SM_RECORD['value'])
 
-    def test_appending_new_record_with_larger_timestamp(self, example_sm_record, job_scalar_helper):
-        dataframe = pd.DataFrame.from_dict([example_sm_record])
+    def test_appending_new_record_with_larger_timestamp(self, job_scalar_helper):
+        dataframe = pd.DataFrame.from_dict([TestJobScalarHelper.EXAMPLE_SM_RECORD])
         sagemaker_job = job_scalar_helper.job
 
         job_scalar_helper.add_new_scalars_from(dataframe)
 
         # Create new record
-        new_record = example_sm_record.copy()
+        new_record = TestJobScalarHelper.EXAMPLE_SM_RECORD.copy()
         new_record.update(timestamp=1.0, value=23.0)
-        dataframe_with_two_records = pd.DataFrame.from_dict([example_sm_record, new_record])
+        dataframe_with_two_records = pd.DataFrame.from_dict([TestJobScalarHelper.EXAMPLE_SM_RECORD, new_record])
 
         job_scalar_helper.add_new_scalars_from(dataframe_with_two_records)
 
         assert sagemaker_job.add_scalar_to_history.call_count == 2, "Expected scalar to have been added only twice"
 
         sagemaker_job.add_scalar_to_history.assert_any_call(
-            scalar_name=example_sm_record['metric_name'],
-            scalar_value=example_sm_record['value'])
+            scalar_name=TestJobScalarHelper.EXAMPLE_SM_RECORD['metric_name'],
+            scalar_value=TestJobScalarHelper.EXAMPLE_SM_RECORD['value'])
 
         sagemaker_job.add_scalar_to_history.assert_called_with(
             scalar_name=new_record['metric_name'],
             scalar_value=new_record['value'])
 
-    def test_appending_new_record_with_different_name(self, example_sm_record, job_scalar_helper):
-        dataframe = pd.DataFrame.from_dict([example_sm_record])
+    def test_appending_new_record_with_different_name(self, job_scalar_helper):
+        dataframe = pd.DataFrame.from_dict([TestJobScalarHelper.EXAMPLE_SM_RECORD])
         sagemaker_job = job_scalar_helper.job
 
         job_scalar_helper.add_new_scalars_from(dataframe)
 
         # Create new record
-        new_record = example_sm_record.copy()
+        new_record = TestJobScalarHelper.EXAMPLE_SM_RECORD.copy()
         new_record.update(timestamp=-1.0, metric_name="val:loss")
 
-        dataframe_with_two_records = pd.DataFrame.from_dict([new_record, example_sm_record])
+        dataframe_with_two_records = pd.DataFrame.from_dict([new_record, TestJobScalarHelper.EXAMPLE_SM_RECORD])
 
         job_scalar_helper.add_new_scalars_from(dataframe_with_two_records)
 
         assert sagemaker_job.add_scalar_to_history.call_count == 2, "Expected scalar to have been added only twice"
 
         sagemaker_job.add_scalar_to_history.assert_any_call(
-            scalar_name=example_sm_record['metric_name'],
-            scalar_value=example_sm_record['value'])
+            scalar_name=TestJobScalarHelper.EXAMPLE_SM_RECORD['metric_name'],
+            scalar_value=TestJobScalarHelper.EXAMPLE_SM_RECORD['value'])
 
         sagemaker_job.add_scalar_to_history.assert_called_with(
             scalar_name=new_record['metric_name'],

--- a/tests/test_sagemaker_monitor.py
+++ b/tests/test_sagemaker_monitor.py
@@ -7,7 +7,7 @@ import pytest
 import sagemaker
 
 from meeshkan.core.job import SageMakerJob, JobStatus
-from meeshkan.core.sagemaker_monitor import SageMakerJobMonitor, SageMakerHelper, ScalarHelper
+from meeshkan.core.sagemaker_monitor import SageMakerJobMonitor, SageMakerHelper, JobScalarHelper
 
 from meeshkan import exceptions
 
@@ -165,7 +165,7 @@ def sagemaker_job(sagemaker_job_monitor):
 @pytest.fixture
 def job_scalar_helper():
     sagemaker_job = create_autospec(SageMakerJob).return_value
-    return ScalarHelper(job=sagemaker_job)
+    return JobScalarHelper(job=sagemaker_job)
 
 
 class TestJobScalarHelper:


### PR DESCRIPTION
- Add new `JobScalarHelper` class taking care of keeping track of maximum timestamps seen so far per metric name
- Refactor `poll_updates` a bit, move most of the stuff happening inside the `while`-loop to be inside `check_and_apply_updates` method.
- Notifications for multiple metrics make sense now (though tracking "epoch" does not make much sense currently):
<img width="397" alt="screenshot 2019-01-15 at 16 29 28" src="https://user-images.githubusercontent.com/11660974/51186666-cea36100-18e2-11e9-8dd3-794ef9bb680f.png">
