### PR TITLE
Add readthedocs yml.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+# https://docs.readthedocs.io/en/latest/yaml-config.html
+build:
+    image: latest
+
+python:
+    version: 3.6
+    pip_install: true
+    extra_requirements:
+    - dev


### PR DESCRIPTION
The configuration file is documented [here](https://docs.readthedocs.io/en/latest/yaml-config.html). The given configuration should run `pip install .[dev]` which I guess should work. It would make sense to use `setup_py_install: true` but I don't see how to include the `dev` dependencies in that case.