### PR TITLE
Link to Python bug tracker for macOS spawn crash

### DIFF
--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -105,6 +105,7 @@ def start() -> str:
     cloud_client = __utils__._build_cloud_client(config, credentials)  # pylint: disable=protected-access
     cloud_client.notify_service_start()
     cloud_client_serialized = dill.dumps(cloud_client, recurse=True).decode('cp437')
+    # TODO - Keep track of 'spawn' related crashes on macOS: https://bugs.python.org/issue33725
     pyro_uri = service.start(mp.get_context("spawn"), cloud_client_serialized=cloud_client_serialized)
     print('Service started.')
     cloud_client.close()

--- a/meeshkan/api/__init__.py
+++ b/meeshkan/api/__init__.py
@@ -9,3 +9,4 @@ from .utils import *  # pylint: disable=wildcard-import
 
 __all__ = scalars.__all__
 __all__ += conditions.__all__
+__all__ += utils.__all__

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -68,7 +68,7 @@ class Service:
         if pid > 0:  # Close parent process
             return
         if not self.terminate_daemon:
-            self.terminate_daemon = multiprocessing.get_context("spawn").Event()
+            self.terminate_daemon = asyncio.Event()  # Only have one spawned process and semaphore tracker
         remove_non_file_handlers()
         os.setsid()  # Separate from tty
         cloud_client = dill.loads(serialized.encode('cp437'))


### PR DESCRIPTION
- [x] Add `TODO` note with link to Python bug tracker regarding macOS spawn crash
- [x] Remove one semaphore tracker by changing service termination `Event` to use `asyncio`