### PR TITLE
Adds Serializer class to core package

### DIFF
--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -4,6 +4,8 @@ from . import core
 from .core import *  # pylint: disable=wildcard-import
 from . import api
 from .api import *  # pylint: disable=wildcard-import
+# TODO - this import system works mainly with submodules; `agent` and accompanying `__utils__` should be moved to their
+#        own submodule
 from . import agent
 from .agent import *  # pylint: disable=wildcard-import
 from . import notifications

--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -9,14 +9,13 @@ import Pyro4
 from . import __utils__
 from .core.config import init_config, ensure_base_dirs
 from .core.service import Service
-from .core.serializer import DillSerializer
+from .core.serializer import Serializer
 from .__version__ import __version__
 
 LOGGER = logging.getLogger(__name__)
-SERIALIZER = DillSerializer()
 
-Pyro4.config.SERIALIZER = str(SERIALIZER)
-Pyro4.config.SERIALIZERS_ACCEPTED.add(str(SERIALIZER))
+Pyro4.config.SERIALIZER = Serializer.NAME
+Pyro4.config.SERIALIZERS_ACCEPTED.add(Serializer.NAME)
 Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
 __all__ = ["start", "init", "stop", "restart"]
 
@@ -104,7 +103,7 @@ def start() -> str:
 
     cloud_client = __utils__._build_cloud_client(config, credentials)  # pylint: disable=protected-access
     cloud_client.notify_service_start()
-    cloud_client_serialized = SERIALIZER(cloud_client)
+    cloud_client_serialized = Serializer.serialize(cloud_client)
     # TODO - Keep track of 'spawn' related crashes on macOS: https://bugs.python.org/issue33725
     pyro_uri = service.start(mp.get_context("spawn"), cloud_client_serialized=cloud_client_serialized)
     print('Service started.')

--- a/meeshkan/api/conditions.py
+++ b/meeshkan/api/conditions.py
@@ -1,7 +1,7 @@
 import os
-import dill
 
 from ..core.service import Service
+from ..core.serializer import DillSerializer
 
 __all__ = ["add_condition"]
 
@@ -20,6 +20,5 @@ def add_condition(*vals, condition, only_reported=False):
 
     pid = os.getpid()
     with Service().api as proxy:
-        # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
-        # recurse==True also packs relevant modules etc and imports if needed and declared in a different module...
-        proxy.add_condition(pid, dill.dumps(condition, recurse=True).decode('cp437'), only_reported, *vals)
+        serializer = DillSerializer()
+        proxy.add_condition(pid, serializer(condition), only_reported, *vals)

--- a/meeshkan/api/conditions.py
+++ b/meeshkan/api/conditions.py
@@ -1,7 +1,7 @@
 import os
 
 from ..core.service import Service
-from ..core.serializer import DillSerializer
+from ..core.serializer import Serializer
 
 __all__ = ["add_condition"]
 
@@ -20,5 +20,4 @@ def add_condition(*vals, condition, only_reported=False):
 
     pid = os.getpid()
     with Service().api as proxy:
-        serializer = DillSerializer()
-        proxy.add_condition(pid, serializer(condition), only_reported, *vals)
+        proxy.add_condition(pid, Serializer.serialize(condition), only_reported, *vals)

--- a/meeshkan/core/__init__.py
+++ b/meeshkan/core/__init__.py
@@ -13,6 +13,8 @@ from .tasks import *  # pylint: disable=wildcard-import
 from . import api
 from .api import *  # pylint: disable=wildcard-import
 from . import config
+from .serializer import *  # pylint: disable=wildcard-import
+from . import serializer
 
 
 # Only expose whatever is listed in modules' __all__ to top level.
@@ -24,3 +26,4 @@ __all__ += scheduler.__all__
 __all__ += service.__all__
 __all__ += tasks.__all__
 __all__ += api.__all__
+__all__ += serializer.__all__

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -14,7 +14,7 @@ from .service import Service
 from .tasks import TaskPoller, Task, TaskType
 from ..notifications.notifiers import Notifier
 from ..__types__ import HistoryByScalar
-from .serializer import DillSerializer
+from .serializer import Serializer
 
 __all__ = ["Api"]
 
@@ -181,8 +181,7 @@ class Api:
     @Pyro4.expose
     def add_condition(self, pid, condition, only_relevant, *vals):
         """Sets a condition for notifications"""
-        serializer = DillSerializer()
-        self.scheduler.add_condition(pid, *vals, condition=serializer(condition), only_relevant=only_relevant)
+        self.scheduler.add_condition(pid, *vals, condition=Serializer.serialize(condition), only_relevant=only_relevant)
 
     @Pyro4.expose
     def get_updates(self, job_id: uuid.UUID) -> HistoryByScalar:

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -4,7 +4,6 @@ import uuid
 from pathlib import Path
 from fnmatch import fnmatch
 
-import dill
 import Pyro4
 import Pyro4.errors
 
@@ -15,6 +14,7 @@ from .service import Service
 from .tasks import TaskPoller, Task, TaskType
 from ..notifications.notifiers import Notifier
 from ..__types__ import HistoryByScalar
+from .serializer import DillSerializer
 
 __all__ = ["Api"]
 
@@ -181,8 +181,8 @@ class Api:
     @Pyro4.expose
     def add_condition(self, pid, condition, only_relevant, *vals):
         """Sets a condition for notifications"""
-        self.scheduler.add_condition(pid, *vals, condition=dill.loads(condition.encode('cp437')),
-                                     only_relevant=only_relevant)
+        serializer = DillSerializer()
+        self.scheduler.add_condition(pid, *vals, condition=serializer(condition), only_relevant=only_relevant)
 
     @Pyro4.expose
     def get_updates(self, job_id: uuid.UUID) -> HistoryByScalar:

--- a/meeshkan/core/serializer.py
+++ b/meeshkan/core/serializer.py
@@ -1,0 +1,36 @@
+"""Serializer class to control Pyro4 (de)serialization"""
+import importlib
+from typing import List
+
+__all__ = []  # type: List[str]
+
+class BaseSerializer:
+    """Base class for serializer object. Provides consistency and shortcuts across the code."""
+    def serialize(self, content):
+        raise NotImplementedError
+
+    def deserialize(self, content):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def __call__(self, content):
+        return self.serialize(content)
+
+
+class DillSerializer(BaseSerializer):
+    def __init__(self, encoding='cp437'):
+        # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
+        # recurse==True also packs relevant modules etc and imports if needed and declared in a different module...
+        self.lib = importlib.import_module('dill')
+        self.encoding = encoding
+
+    def __str__(self):
+        return self.lib.__name__
+
+    def serialize(self, content):
+        return self.lib.dumps(content, recurse=True).decode(self.encoding)
+
+    def deserialize(self, content):
+        return self.lib.loads(content.encode(self.encoding))

--- a/meeshkan/core/serializer.py
+++ b/meeshkan/core/serializer.py
@@ -4,33 +4,17 @@ from typing import List
 
 __all__ = []  # type: List[str]
 
-class BaseSerializer:
-    """Base class for serializer object. Provides consistency and shortcuts across the code."""
-    def serialize(self, content):
-        raise NotImplementedError
+class Serializer:
+    # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
+    # recurse==True also packs relevant modules etc and imports if needed and declared in a different module...
+    LIB = importlib.import_module('dill')
+    ENCODING = 'cp437'
+    NAME = 'dill'
 
-    def deserialize(self, content):
-        raise NotImplementedError
+    @staticmethod
+    def serialize(content):
+        return Serializer.LIB.dumps(content, recurse=True).decode(Serializer.ENCODING)
 
-    def __str__(self):
-        raise NotImplementedError
-
-    def __call__(self, content):
-        return self.serialize(content)
-
-
-class DillSerializer(BaseSerializer):
-    def __init__(self, encoding='cp437'):
-        # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
-        # recurse==True also packs relevant modules etc and imports if needed and declared in a different module...
-        self.lib = importlib.import_module('dill')
-        self.encoding = encoding
-
-    def __str__(self):
-        return self.lib.__name__
-
-    def serialize(self, content):
-        return self.lib.dumps(content, recurse=True).decode(self.encoding)
-
-    def deserialize(self, content):
-        return self.lib.loads(content.encode(self.encoding))
+    @staticmethod
+    def deserialize(content):
+        return Serializer.LIB.loads(content.encode(Serializer.ENCODING))

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -13,7 +13,7 @@ import Pyro4  # For daemon management
 
 from .logger import remove_non_file_handlers
 from ..__build__ import _build_api
-from .serializer import DillSerializer
+from .serializer import Serializer
 
 LOGGER = logging.getLogger(__name__)
 DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
@@ -71,10 +71,9 @@ class Service:
             self.terminate_daemon = asyncio.Event()  # Only have one spawned process and semaphore tracker
         remove_non_file_handlers()
         os.setsid()  # Separate from tty
-        serializer = DillSerializer()
-        cloud_client = serializer.deserialize(serialized)
-        Pyro4.config.SERIALIZER = str(serializer)
-        Pyro4.config.SERIALIZERS_ACCEPTED.add(str(serializer))
+        cloud_client = Serializer.deserialize(serialized)
+        Pyro4.config.SERIALIZER = Serializer.NAME
+        Pyro4.config.SERIALIZERS_ACCEPTED.add(Serializer.NAME)
         Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
         with _build_api(self, cloud_client=cloud_client) as api, Pyro4.Daemon(host=self.host, port=self.port) as daemon:
             daemon.register(api, Service.OBJ_NAME)  # Register the API with the daemon

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -71,7 +71,7 @@ class Service:
         service = Service(terminate_daemon_event=asyncio.Event())
         remove_non_file_handlers()
         os.setsid()  # Separate from tty
-        cloud_client = Serializer.deserialize(serialized)
+        cloud_client = Serializer.deserialize(cloud_client_serialized)
         Pyro4.config.SERIALIZER = Serializer.NAME
         Pyro4.config.SERIALIZERS_ACCEPTED.add(Serializer.NAME)
         Pyro4.config.SERIALIZERS_ACCEPTED.add('json')

--- a/meeshkan/sagemaker/lib.py
+++ b/meeshkan/sagemaker/lib.py
@@ -7,9 +7,6 @@ from ..core.job import SageMakerJob
 
 __all__ = ["monitor"]  # type: List[str]
 
-Pyro4.config.SERIALIZER = 'dill'
-
-
 def monitor(job_name: str, poll_interval: Optional[float] = None):
     """
     Start monitoring a SageMaker training job.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,12 +1,13 @@
 import multiprocessing as mp
 from unittest.mock import create_autospec
 
-import dill
 import pytest
 from meeshkan.core.service import Service
+from meeshkan.core.serializer import DillSerializer
 from .utils import PicklableMock
 
 MP_CTX = mp.get_context("spawn")
+SERIALIZER = DillSerializer()
 
 
 @pytest.fixture
@@ -29,16 +30,16 @@ def service():
 
 
 def test_start_stop(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
-    service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+    service.start(MP_CTX, SERIALIZER(mock_cloud_client))
     assert service.is_running()
     stop_if_running(service_=service)
     assert not service.is_running()
 
 
 def test_double_start(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
-    service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+    service.start(MP_CTX, SERIALIZER(mock_cloud_client))
     assert service.is_running()
     with pytest.raises(RuntimeError):
-        service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+        service.start(MP_CTX, SERIALIZER(mock_cloud_client))
     stop_if_running(service_=service)
     assert not service.is_running()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3,12 +3,10 @@ from unittest.mock import create_autospec
 
 import pytest
 from meeshkan.core.service import Service
-from meeshkan.core.serializer import DillSerializer
+from meeshkan.core.serializer import Serializer
 from .utils import PicklableMock
 
 MP_CTX = mp.get_context("spawn")
-SERIALIZER = DillSerializer()
-
 
 @pytest.fixture
 def mock_cloud_client():
@@ -30,16 +28,16 @@ def service():
 
 
 def test_start_stop(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
-    service.start(MP_CTX, SERIALIZER(mock_cloud_client))
+    service.start(MP_CTX, Serializer.serialize(mock_cloud_client))
     assert service.is_running()
     stop_if_running(service_=service)
     assert not service.is_running()
 
 
 def test_double_start(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
-    service.start(MP_CTX, SERIALIZER(mock_cloud_client))
+    service.start(MP_CTX, Serializer.serialize(mock_cloud_client))
     assert service.is_running()
     with pytest.raises(RuntimeError):
-        service.start(MP_CTX, SERIALIZER(mock_cloud_client))
+        service.start(MP_CTX, Serializer.serialize(mock_cloud_client))
     stop_if_running(service_=service)
     assert not service.is_running()


### PR DESCRIPTION
- Adds a Serializer class to the core package, defining a common interface to be used:
  - `serializer.serialize(content)` (and also `serializer(content)`)
  - `serializer.deserialize(content)`
  - `__str__` so a `Serializer` object can be passed to `Pyro4` if needed.
- Implements `DillSerializer` with a default encoding.