### PR TITLE
Clean Service to have more static variables and methods.

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -79,21 +79,23 @@ def start():
         print(ex.message)
         sys.exit(1)
     except Exception as ex:  # pylint: disable=broad-except
-        print("Starting service failed.")
+        print("Starting the Meeshkan agent failed :'( Please try again.")
+        print("If the problem persists, "
+              "please let us know in the meeshkan-community Slack channel or create an issue in GitHub: "
+              "https://github.com/Meeshkan/meeshkan-client/issues")
         LOGGER.exception("Starting service failed.")
-        # sys.exit(1)
         raise
 
 
 @cli.command(name='status')
 def daemon_status():
     """Checks and returns the service daemon status."""
-    service = Service()
-    is_running = service.is_running()
+    is_running = Service.is_running()
     status = "up and running" if is_running else "configured to run"
-    print("Service is {status} on {host}:{port}".format(status=status, host=service.host, port=service.port))
+    print("Service is {status} on {host}:{port}".format(status=status, host=Service.HOST,
+                                                        port=Service.PORT))
     if is_running:
-        print("URI for Daemon is {uri}".format(uri=service.uri))
+        print("URI for Daemon is {uri}".format(uri=Service.URI))
 
 
 @cli.command()

--- a/meeshkan/__utils__.py
+++ b/meeshkan/__utils__.py
@@ -29,11 +29,10 @@ def save_token(token: str):
 
 
 def _get_api() -> Api:
-    service = Service()
-    if not service.is_running():
+    if not Service.is_running():
         print("Start the service first.")
         raise AgentNotAvailableException()
-    api = service.api  # type: Api
+    api = Service.api()  # type: Api
     return api
 
 

--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -62,7 +62,7 @@ def init(token: Optional[str] = None):
 
 
 def _stop_if_running() -> bool:
-    if Service().is_running():
+    if Service.is_running():
         print("Stopping service...")
         api = __utils__._get_api()  # pylint: disable=protected-access
         api.stop()

--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -1,5 +1,4 @@
 from distutils.version import StrictVersion
-import multiprocessing as mp
 import logging
 from typing import Optional
 
@@ -95,10 +94,9 @@ def start() -> str:
     :return str: Pyro server URI.
     """
     __verify_version()
-    service = Service()
-    if service.is_running():
+    if Service.is_running():
         print("Service is already running.")
-        return service.uri
+        return Service.URI
 
     config, credentials = __utils__.get_auth()
 
@@ -106,7 +104,7 @@ def start() -> str:
     cloud_client.notify_service_start()
     cloud_client_serialized = dill.dumps(cloud_client, recurse=True).decode('cp437')
     # TODO - Keep track of 'spawn' related crashes on macOS: https://bugs.python.org/issue33725
-    pyro_uri = service.start(mp.get_context("spawn"), cloud_client_serialized=cloud_client_serialized)
+    pyro_uri = Service.start(cloud_client_serialized=cloud_client_serialized)
     print('Service started.')
     cloud_client.close()
     return pyro_uri

--- a/meeshkan/api/conditions.py
+++ b/meeshkan/api/conditions.py
@@ -19,7 +19,7 @@ def add_condition(*vals, condition, only_reported=False):
         raise RuntimeError("No arguments given for condition!")
 
     pid = os.getpid()
-    with Service().api as proxy:
+    with Service.api() as proxy:
         # Uses old encoding, see https://stackoverflow.com/a/27527728/4133131
         # recurse==True also packs relevant modules etc and imports if needed and declared in a different module...
         proxy.add_condition(pid, dill.dumps(condition, recurse=True).decode('cp437'), only_reported, *vals)

--- a/meeshkan/api/scalars.py
+++ b/meeshkan/api/scalars.py
@@ -18,7 +18,7 @@ def report_scalar(val_name, value, *vals) -> bool:
         raise RuntimeError("Invalid number of arguments given - did you forget a name/value?")
 
     pid = os.getpid()
-    with Service().api as proxy:
+    with Service.api() as proxy:
         try:
             proxy.report_scalar(pid, val_name, value)
             for name, val in zip(vals[::2], vals[1::2]):

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -23,59 +23,68 @@ DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
 __all__ = []  # type: List[str]
 
 
+def _get_localhost():
+    if sys.platform.startswith('darwin'):
+        # Mac OS has issues with `socket.gethostname()`
+        # See https://bugs.python.org/issue29705 and https://bugs.python.org/issue35164
+        return socket.gethostbyname("localhost")  # Assume localhost defined in `hosts`
+    return socket.gethostname()
+
+
 class Service:
     """
     Service for running the Python daemon
     """
     OBJ_NAME = "Meeshkan.scheduler"
+    PORT = 7779
+    HOST = _get_localhost()
+    MULTIPROCESSING_CONTEXT = multiprocessing.get_context("spawn")
+    URI = "PYRO:{obj_name}@{host}:{port}".format(obj_name=OBJ_NAME,
+                                                 host=HOST,
+                                                 port=PORT)
 
-    def __init__(self, port: int = 7779):
-        self.port = port
-        self.host = Service._get_localhost()
+    def __init__(self):
         self.terminate_daemon = None  # Set at start time
 
     @staticmethod
-    def _get_localhost():
-        if sys.platform.startswith('darwin'):
-            # Mac OS has issues with `socket.gethostname()`
-            # See https://bugs.python.org/issue29705 and https://bugs.python.org/issue35164
-            return socket.gethostbyname("localhost")  # Assume localhost defined in `hosts`
-        return socket.gethostname()
-
-    def is_running(self) -> bool:
+    def is_running() -> bool:
         """Checks whether the daemon is running on localhost.
         Assumes the port is either taken by Pyro or is free.
-        Offered as an alternative as `is_running2` requires `sudo` on MacOS systems.
         """
-        with Pyro4.Proxy(self.uri) as pyro_proxy:
+        with Pyro4.Proxy(Service.URI) as pyro_proxy:
             try:
                 pyro_proxy._pyroBind()  # pylint: disable=protected-access
                 return True
             except Pyro4.errors.CommunicationError:
                 return False
 
-    @property
-    def api(self) -> Pyro4.Proxy:
-        return Pyro4.Proxy(self.uri)
+    @staticmethod
+    def api() -> Pyro4.Proxy:
+        return Pyro4.Proxy(Service.URI)
 
-    @property
-    def uri(self):
-        return "PYRO:{obj_name}@{host}:{port}".format(obj_name=Service.OBJ_NAME, host=self.host, port=self.port)
+    @staticmethod
+    def uri() -> str:
+        return "PYRO:{obj_name}@{host}:{port}".format(obj_name=Service.OBJ_NAME,
+                                                      host=Service.HOST,
+                                                      port=Service.PORT)
 
-    def daemonize(self, serialized):
+    @staticmethod
+    def daemonize(serialized):
         """Makes sure the daemon runs even if the process that called `start_scheduler` terminates"""
         pid = os.fork()
         if pid > 0:  # Close parent process
             return
-        if not self.terminate_daemon:
-            self.terminate_daemon = asyncio.Event()  # Only have one spawned process and semaphore tracker
+        service = Service()
+        if not service.terminate_daemon:
+            service.terminate_daemon = asyncio.Event()  # Only have one spawned process and semaphore tracker
         remove_non_file_handlers()
         os.setsid()  # Separate from tty
         cloud_client = dill.loads(serialized.encode('cp437'))
         Pyro4.config.SERIALIZER = 'dill'
         Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
         Pyro4.config.SERIALIZERS_ACCEPTED.add('json')
-        with _build_api(self, cloud_client=cloud_client) as api, Pyro4.Daemon(host=self.host, port=self.port) as daemon:
+        with _build_api(service, cloud_client=cloud_client) as api,\
+                Pyro4.Daemon(host=Service.HOST, port=Service.PORT) as daemon:
             daemon.register(api, Service.OBJ_NAME)  # Register the API with the daemon
 
             async def start_daemon_and_polling_loops():
@@ -89,7 +98,7 @@ class Service:
                 with concurrent.futures.ThreadPoolExecutor() as pool:
                     try:
                         loop_daemon_until_event_set = partial(daemon.requestLoop,
-                                                              lambda: not self.terminate_daemon.is_set())
+                                                              lambda: not service.terminate_daemon.is_set())
                         await loop.run_in_executor(pool, loop_daemon_until_event_set)
                     finally:
                         LOGGER.debug("Canceling polling task.")
@@ -106,24 +115,26 @@ class Service:
 
         return
 
-    def start(self, mp_ctx, cloud_client_serialized: str) -> str:
+    @staticmethod
+    def start(cloud_client_serialized: str) -> str:
         """
         Runs the scheduler as a Pyro4 object on a predetermined location in a subprocess.
-        :param mp_ctx: Multiprocessing context, e.g. `multiprocessing.get_context("spawn")`
         :param cloud_client_serialized: Dill-serialized CloudClient instance
         :return: Pyro URI
         """
 
-        if self.is_running():
-            raise RuntimeError("Running already at {uri}".format(uri=self.uri))
+        if Service.is_running():
+            raise RuntimeError("Running already at {uri}".format(uri=Service.URI))
         LOGGER.info("Starting service...")
-        proc = mp_ctx.Process(target=self.daemonize, args=[cloud_client_serialized])
+        proc = Service.MULTIPROCESSING_CONTEXT.Process(
+            target=Service.daemonize,
+            args=[cloud_client_serialized])
         proc.daemon = True
         proc.start()
         proc.join()
         time.sleep(DAEMON_BOOT_WAIT_TIME)  # Allow Pyro to boot up
         LOGGER.info("Service started.")
-        return self.uri
+        return Service.URI
 
     def stop(self) -> bool:
         if self.is_running():
@@ -131,7 +142,7 @@ class Service:
                 raise RuntimeError("Terminate daemon event does not exist. "
                                    "The stop() method may have called from the wrong process.")
             self.terminate_daemon.set()  # Flag for requestLoop to terminate
-            with Pyro4.Proxy(self.uri) as pyro_proxy:
+            with Service.api() as pyro_proxy:
                 # triggers checking loopCondition
                 pyro_proxy._pyroBind()  # pylint: disable=protected-access
             return True

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -110,8 +110,8 @@ class Service:
     @staticmethod
     def start(cloud_client_serialized: str) -> str:
         """
-        Runs the scheduler as a Pyro4 object on a predetermined location in a subprocess.
-        :param cloud_client_serialized: Dill-serialized CloudClient instance
+        Runs the agent as a Pyro4 object on a predetermined location in a subprocess.
+        :param cloud_client_serialized: Serialized CloudClient instance
         :return: Pyro URI
         """
 

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -63,12 +63,6 @@ class Service:
         return Pyro4.Proxy(Service.URI)
 
     @staticmethod
-    def uri() -> str:
-        return "PYRO:{obj_name}@{host}:{port}".format(obj_name=Service.OBJ_NAME,
-                                                      host=Service.HOST,
-                                                      port=Service.PORT)
-
-    @staticmethod
     def daemonize(serialized):
         """Makes sure the daemon runs even if the process that called `start_scheduler` terminates"""
         pid = os.fork()

--- a/meeshkan/sagemaker/lib.py
+++ b/meeshkan/sagemaker/lib.py
@@ -18,7 +18,7 @@ def monitor(job_name: str, poll_interval: Optional[float] = None):
     :param poll_interval: Polling interval in seconds, optional. Defaults to one hour.
     :return: SageMakerJob instance
     """
-    with Service().api as proxy:
+    with Service.api() as proxy:
         sagemaker_job = proxy.monitor_sagemaker(job_name=job_name, poll_interval=poll_interval)  # type: SageMakerJob
         if sagemaker_job.status.is_processed:
             print("Job {job_name} is already finished with status {status}.".format(job_name=sagemaker_job.name,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,12 +1,7 @@
-import multiprocessing as mp
-from unittest.mock import create_autospec
-
 import dill
 import pytest
 from meeshkan.core.service import Service
 from .utils import PicklableMock
-
-MP_CTX = mp.get_context("spawn")
 
 
 @pytest.fixture
@@ -14,31 +9,23 @@ def mock_cloud_client():
     return PicklableMock()
 
 
-def stop_if_running(service_):
-    if service_.is_running():
-        with service_.api as api:
+def stop_if_running():
+    if Service.is_running():
+        with Service.api() as api:
             api.stop()
 
 
-@pytest.fixture
-def service():
-    service_ = Service()
-    stop_if_running(service_)
-    yield service_
-    stop_if_running(service_)
+def test_start_stop(mock_cloud_client):  # pylint:disable=redefined-outer-name
+    Service.start(dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+    assert Service.is_running()
+    stop_if_running()
+    assert not Service.is_running()
 
 
-def test_start_stop(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
-    service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
-    assert service.is_running()
-    stop_if_running(service_=service)
-    assert not service.is_running()
-
-
-def test_double_start(service, mock_cloud_client):  # pylint:disable=redefined-outer-name
-    service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
-    assert service.is_running()
+def test_double_start(mock_cloud_client):  # pylint:disable=redefined-outer-name
+    Service.start(dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+    assert Service.is_running()
     with pytest.raises(RuntimeError):
-        service.start(MP_CTX, dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
-    stop_if_running(service_=service)
-    assert not service.is_running()
+        Service.start(dill.dumps(mock_cloud_client, recurse=True).decode('cp437'))
+    stop_if_running()
+    assert not Service.is_running()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -147,8 +147,6 @@ def test_version_mismatch(pre_post_tests):  # pylint:disable=unused-argument,red
 
 
 def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
-
     # Patch CloudClient as it connects to cloud at start-up
     # Lots of reverse-engineering happening here...
     with mock.patch(BUILD_CLOUD_CLIENT_PATCH_PATH) as mock_build_cloud_client:
@@ -157,9 +155,9 @@ def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefine
         mock_cloud_client.notify_service_start.return_value = None
         start_result = run_cli('start')
         assert start_result.exit_code == 0
-        assert service.is_running(), "Service should be running after using `meeshkan start`"
+        assert Service.is_running(), "Service should be running after using `meeshkan start`"
         stop_result = run_cli(args=['stop'])
-        assert not service.is_running(), "Service should NOT be running after using `meeshkan stop`"
+        assert not Service.is_running(), "Service should NOT be running after using `meeshkan stop`"
 
     assert start_result.exit_code == 0, "`meeshkan start` is expected to run without errors"
     assert stop_result.exit_code == 0, "`meeshkan stop` is expected to run without errors"
@@ -169,13 +167,12 @@ def test_start_stop(pre_post_tests):  # pylint: disable=unused-argument,redefine
 
 
 def test_double_start(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
     with mock.patch(BUILD_CLOUD_CLIENT_PATCH_PATH) as mock_build_cloud_client:
         mock_cloud_client = PicklableMock()
         mock_build_cloud_client.return_value = mock_cloud_client
         mock_cloud_client.notify_service_start.return_value = None
         start_result = run_cli('start')
-        assert service.is_running(), "Service should be running after using `meeshkan start`"
+        assert Service.is_running(), "Service should be running after using `meeshkan start`"
         double_start_result = run_cli('start')
         assert double_start_result.stdout == "Service is already running.\n", "Service should already be running"
 
@@ -186,8 +183,6 @@ def test_double_start(pre_post_tests):  # pylint: disable=unused-argument,redefi
 
 
 def test_start_fail(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
-
     def fail_notify_start(*args, **kwargs):  # pylint: disable=unused-argument,redefined-outer-name
         raise RuntimeError("Mocking notify service start failure")
 
@@ -199,7 +194,7 @@ def test_start_fail(pre_post_tests):  # pylint: disable=unused-argument,redefine
 
     assert start_result.stdout == "Starting service failed.\n", "`meeshkan start` is expected to fail"
     assert start_result.exit_code == 1, "`meeshkan start` exit code should be non-zero upon failure"
-    assert not service.is_running(), "Service should not be running!"
+    assert not Service.is_running(), "Service should not be running!"
 
 
 def test_help(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
@@ -214,7 +209,6 @@ def test_help(pre_post_tests):  # pylint: disable=unused-argument,redefined-oute
 
 
 def test_start_with_401_fails(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
 
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch(BUILD_CLOUD_CLIENT_PATCH_PATH) as mock_build_cloud_client:
@@ -232,14 +226,12 @@ def test_start_with_401_fails(pre_post_tests):  # pylint: disable=unused-argumen
                                                                                  "start` should match the error " \
                                                                                  "message in " \
                                                                                  "UnauthorizedRequestException"
-    assert not service.is_running(), "Service should not be running after a failed `start`"
+    assert not Service.is_running(), "Service should not be running after a failed `start`"
     assert mock_cloud_client.notify_service_start.call_count == 1, "`notify_service_start` should be " \
                                                                                 "called once (where it fails)"
 
 
 def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
-
     # Patch CloudClient as it connects to cloud at start-up
     with mock.patch(BUILD_CLOUD_CLIENT_PATCH_PATH) as mock_build_cloud_client:
         mock_cloud_client = PicklableMock()
@@ -250,7 +242,7 @@ def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefi
         start_result = run_cli(args=['start'])
 
     assert start_result.exit_code == 0, "`start` should run smoothly"
-    assert service.is_running(), "Service should be running after `start`"
+    assert Service.is_running(), "Service should be running after `start`"
 
     submit_result = run_cli(args='submit echo Hello')
     assert submit_result.exit_code == 0, "`submit` is expected to succeed"
@@ -264,7 +256,7 @@ def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefi
     job_uuid = match.group(2)
     assert uuid.UUID(job_uuid), "Job UUID should be a valid UUID and match the regex pattern"
 
-    assert service.is_running(), "Service should still be running!"
+    assert Service.is_running(), "Service should still be running!"
 
     list_result = run_cli(args='list')
     # Better testing at some point.
@@ -341,7 +333,6 @@ def test_sorry_connection_fail(pre_post_tests):  # pylint: disable=unused-argume
 
 
 def test_empty_list(pre_post_tests):  # pylint: disable=unused-argument,redefined-outer-name
-    service = Service()
     with mock.patch(BUILD_CLOUD_CLIENT_PATCH_PATH) as mock_build_cloud_client:
         mock_cloud_client = PicklableMock()
         mock_build_cloud_client.return_value = mock_cloud_client
@@ -351,7 +342,7 @@ def test_empty_list(pre_post_tests):  # pylint: disable=unused-argument,redefine
         run_cli(args=['start'])
         list_result = run_cli(args=['list'])
 
-    assert service.is_running(), "Service should be running after running `start`"
+    assert Service.is_running(), "Service should be running after running `start`"
     assert list_result.exit_code == 0, "`list` is expected to succeed"
     assert list_result.stdout == "No jobs submitted yet.\n", "`list` output message should match"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,6 @@ def _token_store(build_session=None):
     """Returns a TokenStore for unit testing"""
     _cloud_url = 'favorite-url-yay.com'
     _refresh_token = 'meeshkan-top-secret'
-    # return DummyStore(cloud_url=_cloud_url, refresh_token=_refresh_token)
     if build_session is None:
         return DummyStore(cloud_url=_cloud_url, refresh_token=_refresh_token)
     return DummyStore(cloud_url=_cloud_url, refresh_token=_refresh_token, build_session=build_session)
@@ -47,29 +46,11 @@ def _token_store(build_session=None):
 @pytest.fixture
 def pre_post_tests():
     """Pre- and post-test method to explicitly start and stop various instances."""
-    def _get_fetch_token():
-        """
-        :return: Function returning tokens that increment by one for every call
-        """
-        requests_counter = 0
-
-        def fetch(self):  # pylint:disable=unused-argument
-            nonlocal requests_counter
-            requests_counter += 1
-            return str(requests_counter)
-        return fetch
-
-    def _no_tasks():
-        return []
-    # Stuff before tests
-    # tokenstore_patcher = mock.patch('meeshkan.__main__.cloud.CloudTokenStore', _get_fetch_token())
-    # tokenstore_patcher.start()  # Augment TokenStore
 
     def stop_service():
         run_cli(args=['stop'])
     yield stop_service()
     stop_service()  # Stuff to run after every test
-    # tokenstore_patcher.stop()
 
 
 def test_setup_if_exists(pre_post_tests):  # pylint:disable=unused-argument,redefined-outer-name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -192,7 +192,8 @@ def test_start_fail(pre_post_tests):  # pylint: disable=unused-argument,redefine
         mock_cloud_client.notify_service_start.side_effect = fail_notify_start
         start_result = run_cli('start')
 
-    assert start_result.stdout == "Starting service failed.\n", "`meeshkan start` is expected to fail"
+    assert "Starting the Meeshkan agent failed" in start_result.stdout,\
+        "`meeshkan start` is expected to fail with error message"
     assert start_result.exit_code == 1, "`meeshkan start` exit code should be non-zero upon failure"
     assert not Service.is_running(), "Service should not be running!"
 


### PR DESCRIPTION
- Refactored Service to avoid always initializing `Service()` when accessing e.g. Pyro 
- Changed `start`, `is_running`, `api` etc. to be static methods of `Service`
- Changed `port`, `host`, `URI` to be static variables as they were never changed
- Added better failure message when starting the agent fails.
- Changed `daemonize` to be a static method and only build `Service` instance in after forking, this should reduce coupling between different processes even more
- If e.g. `port` needs to be changed at start-up, I think it should be a configuration variable instead of trying to include it in the `Service` instance. Otherwise it will be hard for the CLI or the library to know where to find Pyro.