### PR TITLE
Add mypy.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,18 +285,23 @@ pip install -e .[dev]
 
 ### Running tests
 ```bash
-pytest
+pytest [-s]
 ```
 
 ### Running lint
 ```bash
 pylint -f msvs meeshkan
 ```
+To check for required coverage:
+```bash
+python run_pylint.py --fail-under=9.75 -f msvs meeshkan
+```
 
 ### Running static type checks
 ```bash
-mypy --ignore-missing-imports meeshkan
+mypy meeshkan
 ```
+The configuration for `mypy` can be found in [mypy.ini](./mypy.ini).
 
 ### Building the documentation
 ```bash

--- a/azure-steps.yml
+++ b/azure-steps.yml
@@ -19,5 +19,5 @@ steps:
   displayName: 'Test with pylint'
 
 - script: |
-    mypy --ignore-missing-imports meeshkan
+    mypy meeshkan
   displayName: 'Static type checking'

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any, Tuple, Union, List, Optional, Dict
+from typing import Callable, Any, Tuple, List, Optional, Dict
 import logging
 import uuid
 from pathlib import Path
@@ -113,7 +113,7 @@ class Api:
 
         if job_id is not None:  # Match by UUID
             job = self.get_job(job_id)
-            if job:
+            if isinstance(job, Job):  # mypy understands this better than "is not None"
                 return job.id
 
         if job_number is not None:  # Match by job number

--- a/meeshkan/core/job.py
+++ b/meeshkan/core/job.py
@@ -54,9 +54,9 @@ class Trackable:
     """
     Base class for all trackable jobs, run by Meeshkan, SageMaker or some other means
     """
-    def __init__(self, scalar_history=None):
+    def __init__(self, scalar_history: Optional[TrackerBase]=None):
         super().__init__()
-        self.scalar_history = scalar_history or TrackerBase()
+        self.scalar_history = scalar_history or TrackerBase()  # type: TrackerBase
 
     def add_scalar_to_history(self, scalar_name, scalar_value) -> Optional[TrackerCondition]:
         return self.scalar_history.add_tracked(scalar_name, scalar_value)
@@ -86,7 +86,7 @@ class BaseJob(Stoppable, Trackable):
                  poll_interval: Optional[float] = None):  # TODO Move also `status` here
         super().__init__()
         self.status = status
-        self.id = job_uuid or uuid.uuid4()  # pylint: disable=invalid-name
+        self.id = job_uuid or uuid.uuid4()  # type: uuid.UUID  # pylint: disable=invalid-name
         self.number = job_number  # Human-readable integer ID
         self.poll_time = poll_interval or Job.DEF_POLLING_INTERVAL  # type: float
         self.created = datetime.datetime.utcnow()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
+# https://mypy.readthedocs.io/en/latest/config_file.html
+
 # Global options:
 
 [mypy]

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 
 [mypy]
 python_version = 3.7
-warn_return_any = True
+warn_return_any = False
 warn_unused_configs = True
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+# Global options:
+
+[mypy]
+python_version = 3.7
+warn_return_any = True
+warn_unused_configs = True
+ignore_missing_imports = True
+
+# Per-module options:
+
+# [mypy-meeshkan.__main__.*]
+# disallow_untyped_defs = True


### PR DESCRIPTION
- mypy.ini could also be used perhaps to ignore specific modules (like __main__) to avoid cluttering the code with `type: ignore` stuff
- Ignored `return Any` warnings, some of them seemed a bit hard to fix but fixed some