### PR TITLE
Add Notebook/IPython support

### DIFF
--- a/meeshkan/core/job/base.py
+++ b/meeshkan/core/job/base.py
@@ -62,7 +62,7 @@ class BaseJob(Stoppable, Trackable):
 class NotebookConverter:
     """Class that converts .ipynb files (version >= 4.0) to .py files.
     Provides the `from_file` method. to match with PythonExporter from `nbconvert`."""
-    def from_file(self, filename, replace_magic=False):
+    def from_file(self, filename, replace_magic=False) -> Tuple[str, None]:
         """Converts .ipynb to list of source code lines; based on specification found at
                 https://nbformat.readthedocs.io/en/latest/format_description.html#code-cells
 

--- a/meeshkan/core/job/base.py
+++ b/meeshkan/core/job/base.py
@@ -13,7 +13,7 @@ from .status import JobStatus
 LOGGER = logging.getLogger(__name__)
 
 # Expose only BaseJob class
-__all__ = ["BaseJob", "NotebookConverter"]
+__all__ = ["BaseJob"]
 
 class Trackable:
     """
@@ -58,34 +58,3 @@ class BaseJob(Stoppable, Trackable):
 
     def terminate(self):
         raise NotImplementedError
-
-
-class NotebookConverter:
-    """Class that converts .ipynb files (version >= 4.0) to .py files.
-    Provides the `from_file` method. to match with PythonExporter from `nbconvert`."""
-    def from_file(self, filename) -> Tuple[str, None]:  # pylint: disable=no-self-use
-        """Converts .ipynb to list of source code lines; based on specification found at
-                https://nbformat.readthedocs.io/en/latest/format_description.html#code-cells
-
-            :param filename: A .ipynb file (or matching format)
-            :return A tuple of list of source code lines (and matching comments), and None, to match the `nbconvert`
-                        API.
-        """
-        source_code = ["#!/usr/bin/env python\n# coding: utf-8\n\n"]  # Initial content
-        with open(filename) as nb_file:
-            json_input = json.load(nb_file)
-        if json_input["nbformat"] != 4:
-            raise RuntimeError("Internal notebook converter only handles notebooks that correspond to the version 4 "
-                               "format. Try installing `nbconvert` (i.e. `pip install nbconvert`) and try again.")
-        ipyfilter = re.compile(r"^\s*?([%!].+|[^\"'#]+?![^\"']+)$")
-        for cell_no, cell in enumerate(json_input["cells"], 1):
-            cell_type = cell["cell_type"]  # TODO: Add support for markdown cells as comments in triple-quotations
-            if cell_type == "code":
-                source_code.append("# cell #{cell_number}\n".format(cell_number=cell_no))
-                for line in cell["source"]:  # Filters magic commands
-                    if ipyfilter.match(line):
-                        line = r"#  " + line
-                    if not line.endswith("\n"):  # Make sure all lines end with newline
-                        line += "\n"
-                    source_code.append(line)
-        return "".join(source_code), None

--- a/meeshkan/core/job/base.py
+++ b/meeshkan/core/job/base.py
@@ -1,7 +1,7 @@
 """Contains the base classes for the Job API, as well as some other _basic functionality_ classes"""
 
 import logging
-from typing import Optional
+from typing import Optional, Tuple
 import uuid
 import datetime
 import json

--- a/meeshkan/core/job/base.py
+++ b/meeshkan/core/job/base.py
@@ -63,7 +63,7 @@ class BaseJob(Stoppable, Trackable):
 class NotebookConverter:
     """Class that converts .ipynb files (version >= 4.0) to .py files.
     Provides the `from_file` method. to match with PythonExporter from `nbconvert`."""
-    def from_file(self, filename) -> Tuple[str, None]:
+    def from_file(self, filename) -> Tuple[str, None]:  # pylint: disable=no-self-use
         """Converts .ipynb to list of source code lines; based on specification found at
                 https://nbformat.readthedocs.io/en/latest/format_description.html#code-cells
 
@@ -72,8 +72,8 @@ class NotebookConverter:
                         API.
         """
         source_code = ["#!/usr/bin/env python\n# coding: utf-8\n\n"]  # Initial content
-        with open(filename) as f:
-            json_input = json.load(f)
+        with open(filename) as nb_file:
+            json_input = json.load(nb_file)
         if json_input["nbformat"] != 4:
             raise RuntimeError("Internal notebook converter only handles notebooks that correspond to the version 4 "
                                "format. Try installing `nbconvert` (i.e. `pip install nbconvert`) and try again.")

--- a/meeshkan/core/job/executables.py
+++ b/meeshkan/core/job/executables.py
@@ -40,6 +40,14 @@ class Executable:
         raise NotImplementedError
 
     @staticmethod
+    def convert_notebook(notebook_file):
+        try:
+            from nbconvert import PythonExporter
+        except ModuleNotFoundError:
+            PythonExporter = NotebookConverter
+        py_code = PythonExporter().from_file(notebook_file)
+
+    @staticmethod
     def to_full_path(args: Tuple[str, ...], cwd: str):
         """Iterates over arg and prepends known files (.sh, .py) with given current working directory.
         Raises exception if any of supported file suffixes cannot be resolved to an existing file.

--- a/meeshkan/core/job/executables.py
+++ b/meeshkan/core/job/executables.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import os
 import subprocess
 
+from .base import NotebookConverter
+
 LOGGER = logging.getLogger(__name__)
 
 # Expose only valid classes
@@ -43,6 +45,7 @@ class Executable:
 
     @staticmethod
     def convert_notebook(notebook_file: str, target: str):
+        # TODO: Should we use this temporary fallback, or just crash if `nbconvert` does not exist?
         try:
             from nbconvert import PythonExporter
         except ModuleNotFoundError:
@@ -102,7 +105,7 @@ class ProcessExecutable(Executable):
         """
         :return: Return code from subprocess
         """
-        if self.output_path is None:
+        if self.output_path is None:  # TODO - should output_path be mandatory?
             self.popen = subprocess.Popen(self.args, stdout=subprocess.PIPE)
             return self._update_pid_and_wait()
 

--- a/meeshkan/core/job/executables.py
+++ b/meeshkan/core/job/executables.py
@@ -20,6 +20,8 @@ class Executable:
         super().__init__()
         self.pid = None  # type: Optional[int]
         self.output_path = output_path  # type: Optional[Path]
+        if self.output_path is not None and not self.output_path.is_dir():
+            self.output_path.mkdir()
 
     def launch_and_wait(self) -> int:  # pylint: disable=no-self-use
         """
@@ -45,7 +47,7 @@ class Executable:
             from nbconvert import PythonExporter
         except ModuleNotFoundError:
             PythonExporter = NotebookConverter
-        py_code = PythonExporter().from_file(notebook_file)
+        py_code, _ = PythonExporter().from_file(notebook_file)
         with open(target, "w") as f:
             f.write(py_code)
             f.flush()
@@ -104,8 +106,6 @@ class ProcessExecutable(Executable):
             self.popen = subprocess.Popen(self.args, stdout=subprocess.PIPE)
             return self._update_pid_and_wait()
 
-        if not self.output_path.is_dir():
-            self.output_path.mkdir()
         with self.stdout.open(mode='w') as f_stdout, self.stderr.open(mode='w') as f_stderr:
             self.popen = subprocess.Popen(self.args, stdout=f_stdout, stderr=f_stderr)
             return self._update_pid_and_wait()

--- a/meeshkan/core/job/executables.py
+++ b/meeshkan/core/job/executables.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 from pathlib import Path
 import os
 import subprocess

--- a/meeshkan/core/job/executables.py
+++ b/meeshkan/core/job/executables.py
@@ -4,8 +4,6 @@ from pathlib import Path
 import os
 import subprocess
 
-from .base import NotebookConverter
-
 LOGGER = logging.getLogger(__name__)
 
 # Expose only valid classes
@@ -45,11 +43,10 @@ class Executable:
 
     @staticmethod
     def convert_notebook(notebook_file: str, target: str):
-        # TODO: Should we use this temporary fallback, or just crash if `nbconvert` does not exist?
         try:
             from nbconvert import PythonExporter
         except ModuleNotFoundError:
-            PythonExporter = NotebookConverter
+            raise RuntimeError("Cannot convert notebook without IPython or `nbconvert`!")
         py_code, _ = PythonExporter().from_file(notebook_file)
         with open(target, "w") as script_fd:
             script_fd.write(py_code)

--- a/meeshkan/core/job/jobs.py
+++ b/meeshkan/core/job/jobs.py
@@ -158,10 +158,21 @@ class Job(BaseJob):  # TODO Change base properties to use composition instead of
 
     @staticmethod
     def __verify_python_executable(args: Tuple[str, ...]):
+        """Checks if the first argument's extension is one of .py, .ipy or .ipynb, and prepends the matching
+        interpreter to args."""
         """Checks if the first argument's extension is .py, and prepends the full path to Python interpreter to args.
         If the full path is unavailable, defaults to using 'python' alias as runtime. """
-        if len(args) > 0:    # pylint: disable=len-as-condition
-            if os.path.splitext(args[0])[1] == ".py":
+        if args:
+            ext = os.path.splitext(args[0])[1]
+            if ext == ".py":
                 #TODO: default executable should be in config.yaml?
                 args = (sys.executable or "python",) + args  # Full path to interpreter or "python" alias by default
+            if ext in [".ipy", ".ipynb"]:
+                # Check if `ipython` is installed
+                import importlib
+                ipython_exists = importlib.util.find_spec("IPython") is not None
+                if ipython_exists:
+                    args = ("ipython",) + args
+                else:  # Default being python; if IPython doesn't exist, magic commands will be eliminated
+                    args = (sys.executable or "python",) + args
         return args

--- a/meeshkan/core/job/jobs.py
+++ b/meeshkan/core/job/jobs.py
@@ -153,8 +153,6 @@ class Job(BaseJob):  # TODO Change base properties to use composition instead of
     def __verify_python_executable(args: Tuple[str, ...]):
         """Checks if the first argument's extension is one of .py, .ipy or .ipynb, and prepends the matching
         interpreter to args."""
-        """Checks if the first argument's extension is .py, and prepends the full path to Python interpreter to args.
-        If the full path is unavailable, defaults to using 'python' alias as runtime. """
         if args:
             ext = os.path.splitext(args[0])[1]
             if ext == ".py":

--- a/meeshkan/core/job/jobs.py
+++ b/meeshkan/core/job/jobs.py
@@ -13,18 +13,11 @@ from ..config import JOBS_DIR
 LOGGER = logging.getLogger(__name__)
 
 # Expose Job, SageMakerJob to upper level
-__all__ = ["Job", "SageMakerJob", "NotebookJob"]  # type: List[str]
+__all__ = ["Job", "SageMakerJob"]  # type: List[str]
 
 
 CANCELED_RETURN_CODES = [-2, -3, -9, -15]  # Signals indicating user-initiated abort
 SUCCESS_RETURN_CODE = [0]  # Completeness, extend later (i.e. consider > 0 return codes as success with message?)
-
-
-class NotebookJob(BaseJob):
-    """
-    Job used to run notebook files (*.ipynb). Converts them to .py files before run.
-    """
-    pass
 
 
 class SageMakerJob(BaseJob):

--- a/meeshkan/core/job/jobs.py
+++ b/meeshkan/core/job/jobs.py
@@ -153,17 +153,18 @@ class Job(BaseJob):  # TODO Change base properties to use composition instead of
     def __verify_python_executable(args: Tuple[str, ...]):
         """Checks if the first argument's extension is one of .py, .ipy or .ipynb, and prepends the matching
         interpreter to args."""
-        if args:
-            ext = os.path.splitext(args[0])[1]
-            if ext == ".py":
-                #TODO: default executable should be in config.yaml?
-                args = (sys.executable or "python",) + args  # Full path to interpreter or "python" alias by default
-            if ext in [".ipy", ".ipynb"]:
-                # Check if `ipython` is installed
-                import importlib
-                ipython_exists = importlib.util.find_spec("IPython") is not None
-                if ipython_exists:
-                    args = ("ipython",) + args
-                else:  # Default being python; if IPython doesn't exist, magic commands will be eliminated
-                    args = (sys.executable or "python",) + args
+        if args is None:
+            return None
+        ext = os.path.splitext(args[0])[1]
+        if ext == ".py":
+            #TODO: default executable should be in config.yaml?
+            args = (sys.executable or "python",) + args  # Full path to interpreter or "python" alias by default
+        if ext in [".ipy", ".ipynb"]:
+            # Check if `ipython` is installed
+            import importlib
+            ipython_exists = importlib.util.find_spec("IPython") is not None
+            if ipython_exists:
+                args = ("ipython",) + args
+            else:  # Default being python; if IPython doesn't exist, magic commands will be eliminated
+                args = (sys.executable or "python",) + args
         return args

--- a/meeshkan/core/job/jobs.py
+++ b/meeshkan/core/job/jobs.py
@@ -13,11 +13,18 @@ from ..config import JOBS_DIR
 LOGGER = logging.getLogger(__name__)
 
 # Expose Job, SageMakerJob to upper level
-__all__ = ["Job", "SageMakerJob"]  # type: List[str]
+__all__ = ["Job", "SageMakerJob", "NotebookJob"]  # type: List[str]
 
 
 CANCELED_RETURN_CODES = [-2, -3, -9, -15]  # Signals indicating user-initiated abort
 SUCCESS_RETURN_CODE = [0]  # Completeness, extend later (i.e. consider > 0 return codes as success with message?)
+
+
+class NotebookJob(BaseJob):
+    """
+    Job used to run notebook files (*.ipynb). Converts them to .py files before run.
+    """
+    pass
 
 
 class SageMakerJob(BaseJob):
@@ -125,6 +132,7 @@ class Job(BaseJob):  # TODO Change base properties to use composition instead of
                 'status': self.status.name,
                 'args': repr(self.executable)}
 
+    # TODO - change to a factory method outside `Job` class?
     @staticmethod
     def create_job(args: Tuple[str, ...], job_number: int, cwd: str = None, name: str = None, poll_interval: int = None,
                    description: str = None, output_path: Optional[Path] = None):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 
 # Required packages.
 # Older version of requests because >= 2.21 conflicts with sagemaker.
-REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib']
+REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib',
+            'nbconvert']
 
 DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sagemaker', 'sphinx',
        'sphinx-click', 'sphinx_rtd_theme']

--- a/tests/resources/dummy_nb.ipynb
+++ b/tests/resources/dummy_nb.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload  # Have some magic functions to convert\n",
+    "%autoreload 2\n",
+    "import numpy as np  # Some non-standard library\n",
+    "import non-existing-module  # Shouldn't fail anyway"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plus_one = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add(*args):  # Some bogus function here\n",
+    "    global add_result\n",
+    "    add_result = 0\n",
+    "    if not args:\n",
+    "        args = sys.argv[1:]\n",
+    "    for val in args:\n",
+    "        add_result += int(val)\n",
+    "    if plus_one:\n",
+    "        add_result += 1\n",
+    "    print(add_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "add(*['3', '5', '1'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = !ls  # Some more magic stuff"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "spam",
+   "language": "python",
+   "name": "foobar"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/resources/logs/stderr
+++ b/tests/resources/logs/stderr
@@ -1,4 +1,4 @@
-  File "/Users/kimmo/git/meeshkan/meeshkan-client/examples/hello_world.py", line 5
+  File "/hidden/meeshkan-client/examples/hello_world.py", line 5
     if __name__ == '__main__':
                              ^
 SyntaxError: invalid syntax

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ from meeshkan.core.service import Service
 from meeshkan.core.job import Job, JobStatus, SageMakerJob
 from meeshkan.core.sagemaker_monitor import SageMakerJobMonitor, SageMakerHelper
 from meeshkan.core.tasks import TaskType, Task
-from meeshkan import exceptions
+from meeshkan import exceptions, config
 
 from .utils import wait_for_true, MockNotifier
 
@@ -22,6 +22,7 @@ def __get_job(sleep_duration=10):
 
 @pytest.fixture
 def cleanup():
+    config.ensure_base_dirs()
     yield None
     # Post-test code
     # Cleanup for `job`, if possible

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ def __get_job(sleep_duration=10):
 
 @pytest.fixture
 def cleanup():
-    config.ensure_base_dirs()
+    config.ensure_base_dirs()  # Make sure all the base directories exist before tests
     yield None
     # Post-test code
     # Cleanup for `job`, if possible

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -115,4 +115,5 @@ def test_executable_notebook_run(notebook_job):
         script_fd.flush()
 
     assert notebook_job.launch_and_wait() == 0, "Expected job to run smoothly"
-    assert notebook_job.stdout.read_text().endswith(expected_outcome), "Expected outcome: 10"
+    with notebook_job.stdout.open('r') as stdout:
+        assert stdout.read().endswith(expected_outcome), "Expected outcome: 10"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -101,7 +101,7 @@ def test_executable_notebook(notebook_job):
     assert open(args[1]).read() == expected_conversion, "Expected output of conversion does not match"
 
 def test_executable_notebook_run(notebook_job):
-    expected_outcome = '\x0710\n'  # ANSI-encoded via IPython interpreter
+    expected_outcome = '10\n'  # ANSI-encoded via IPython interpreter
 
     def clean_failing_lines(line):
         return "non-existing-module" not in line and "run_line_magic" not in line
@@ -115,5 +115,4 @@ def test_executable_notebook_run(notebook_job):
         script_fd.flush()
 
     assert notebook_job.launch_and_wait() == 0, "Expected job to run smoothly"
-    with notebook_job.stdout.open('r') as stdout:
-        assert stdout.read().endswith(expected_outcome), "Expected outcome: 10"
+    assert notebook_job.stdout.read_text().endswith(expected_outcome), "Expected outcome: 10"

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -70,23 +70,22 @@ class TestLoggingNotifier:
         job = _get_job()
         logging_notifier = LoggingNotifier()
 
-        # Job directory doesn't exist but file does exist -> expected a failure in notification!
+        # Job directory is expected to be created upon initialization of Executable
         logging_notifier.notify(job, __file__, -1)
         # Assumes this works from previous tests (and onwards)
         last_notification = logging_notifier.get_last_notification_status(job.id)[logging_notifier.name]
         assert last_notification.type == NotificationType.JOB_UPDATE, "The notification type should be an update " \
                                                                       "pertaining to the job"
-        assert last_notification.status == NotificationStatus.FAILED, "The notification should fail " \
-                                                                      "when the Job output " \
-                                                                      "path does not exist."
+        assert last_notification.status == NotificationStatus.SUCCESS, "The notification should succeed (output path " \
+                                                                       "created when Executable is initialized)"
 
     def test_logging_notifier_job_update_no_file_with_dir(self):  # pylint:disable=unused-argument,redefined-outer-name
         """Tests the job update for LoggingNotifier when an image doesn't exist bu the directory does"""
         job = _get_job()
         logging_notifier = LoggingNotifier()
 
-        job.output_path.mkdir()
-        # Job directory exists but file doesn't -> expected a failure in notification still!
+        # Job directory is expected to be created upon initialization of Executable, but file doesn't ->
+        #     expected a failure in notification still!
         logging_notifier.notify(job, "does_not_exist", -1)
         last_notification = logging_notifier.get_last_notification_status(job.id)[logging_notifier.name]
         assert last_notification.type == NotificationType.JOB_UPDATE, "The notification type should be an update " \
@@ -112,7 +111,6 @@ class TestLoggingNotifier:
         job = _get_job()
         logging_notifier = LoggingNotifier()
 
-        job.output_path.mkdir()
         logging_notifier.notify(job, __file__, -1)
         # Both exist!
         logging_notifier = LoggingNotifier()


### PR DESCRIPTION
The idea with this branch is to add support for `*.ipynb` file. These would be recognized and converted to `.py` files (using `nbconvert` if available or the `NotebookConverter` for notebooks version 4+). Then we can use a regular `Job` to run these.  
The newly created `.py` file will be stored (alongside the notebook) in the matching `job-uuid` directory. Ultimately, this is the support for two functionalities:
- Support from within a notebook to call `meeshkan.run()` (or similar naming), that will compile the notebook and schedule it as needed. This can also be seen as some sort of versioning with testing, etc.
- Support for future `git` related interactions (i.e. `meeshkan run <commit id>` to pull a matching `.py` or `.ipynb` and schedule it).

- [x] Add tests
- [x] Cleanup