### PR TITLE
Initial Git integration

### DIFF
--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -10,6 +10,8 @@ from . import agent
 from .agent import *  # pylint: disable=wildcard-import
 from . import notifications
 from .notifications import *  # pylint: disable=wildcard-import
+from . import git
+from .git import *  # pylint: disable=wildcard-import
 
 from . import exceptions
 from . import sagemaker
@@ -17,7 +19,7 @@ from .__utils__ import save_token
 
 
 # Only make the following available by default
-__all__ = ["__version__", "exceptions", "config", "save_token"]
+__all__ = ["__version__", "exceptions", "config", "save_token", "sagemaker", "git"]
 __all__ += api.__all__
 __all__ += agent.__all__
 __all__ += core.__all__

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -11,7 +11,7 @@ from .agent import *  # pylint: disable=wildcard-import
 from . import notifications
 from .notifications import *  # pylint: disable=wildcard-import
 from . import git
-from .git import *  # pylint: disable=wildcard-import
+# from .git import *  # pylint: disable=wildcard-import
 
 from . import exceptions
 from . import sagemaker

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -12,16 +12,17 @@ from . import agent
 from .agent import *  # pylint: disable=wildcard-import
 from . import notifications
 from .notifications import *  # pylint: disable=wildcard-import
+from . import git
+from .git import *  # pylint: disable=wildcard-import
 
 # The following are available as is; written explicitly also in __all__
-from . import git
 from . import exceptions
 from . import sagemaker
 from .__utils__ import save_token
 
 
 # Only make the following available by default
-__all__ = ["__version__", "exceptions", "config", "save_token", "sagemaker", "git"]
+__all__ = ["__version__", "exceptions", "config", "save_token", "sagemaker", "submit_git"]
 __all__ += api.__all__
 __all__ += agent.__all__
 __all__ += core.__all__
@@ -32,3 +33,4 @@ del core
 del api
 del agent
 del notifications
+del git

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -1,5 +1,7 @@
 from .__version__ import __version__  # Conform to PEP-0396
 
+# The contents of the following is imported to module level, with __all__ extended with their respective __all__
+# These should be `del` later to clean the namespace
 from . import core
 from .core import *  # pylint: disable=wildcard-import
 from . import api
@@ -10,9 +12,9 @@ from . import agent
 from .agent import *  # pylint: disable=wildcard-import
 from . import notifications
 from .notifications import *  # pylint: disable=wildcard-import
-from . import git
-# from .git import *  # pylint: disable=wildcard-import
 
+# The following are available as is; written explicitly also in __all__
+from . import git
 from . import exceptions
 from . import sagemaker
 from .__utils__ import save_token

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -87,7 +87,9 @@ def setup():
             print("Aborting")
             sys.exit(2)
     token = input("Please enter your client secret: ")
-    save_token(token)
+    git_token = input("Please enter a Github access personal access token: ")
+    meeshkan.config.ensure_base_dirs(verbose=False)
+    meeshkan.config.Credentials.to_isi(refresh_token=token, git_token=git_token)
     print("You're all set up! Now run \"meeshkan start\" to start the service.")
 
 

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -87,9 +87,9 @@ def setup():
             print("Aborting")
             sys.exit(2)
     token = input("Please enter your client secret: ")
-    git_token = input("Please enter a Github access personal access token: ")
+    git_token = input("[Optional] Please enter a Github personal access token (or enter to skip): ")
     meeshkan.config.ensure_base_dirs(verbose=False)
-    meeshkan.config.Credentials.to_isi(refresh_token=token, git_token=git_token)
+    meeshkan.config.Credentials.to_isi(refresh_token=token, git_access_token=git_token)
     print("You're all set up! Now run \"meeshkan start\" to start the service.")
 
 

--- a/meeshkan/api/__init__.py
+++ b/meeshkan/api/__init__.py
@@ -9,6 +9,8 @@ from .utils import *  # pylint: disable=wildcard-import
 from . import external_job
 from .external_job import *  # pylint: disable=wildcard-import
 
+# TODO: Should this take care of importing git subpackage and sagemaker subpackage? Should they be nested here?
+
 __all__ = scalars.__all__
 __all__ += conditions.__all__
 __all__ += utils.__all__

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -14,7 +14,7 @@ __all__ = ["submit_notebook"]
 
 LOGGER = logging.getLogger(__file__)
 
-def submit_notebook(job_name: str = None, poll_interval: Optional[float] = None, notebook_password: str = None):
+def submit_notebook(job_name: str = None, report_interval: Optional[float] = None, notebook_password: str = None):
     """
     Submits the current notebook to the Meeshkan agent. Requires the agent to be running.
     Can only be called from within a notebook instance.
@@ -29,11 +29,12 @@ def submit_notebook(job_name: str = None, poll_interval: Optional[float] = None,
         get_ipython_func = None
 
     try:
+        api = Service.api()  # Raise if agent is not running
         path = _get_notebook_path_generic(get_ipython_function=get_ipython_func,
                                           list_servers_function=notebookapp.list_running_servers,
                                           connection_file_function=ipykernel.get_connection_file,
                                           notebook_password=notebook_password)
-        return Service.api().submit((path,), name=job_name, poll_interval=poll_interval)  # Submit notebook
+        return api.submit((path,), name=job_name, poll_interval=report_interval)  # Submit notebook
     except MismatchingIPythonKernelException:  # Ran from ipython but not from jupyter notebook -> expected behaviour
         print("submit_notebook(): Not run from notebook interpreter; ignoring...")
     return None  # Return None so we don't crash the notebook/caller;

--- a/meeshkan/core/config.py
+++ b/meeshkan/core/config.py
@@ -61,9 +61,9 @@ class Configuration:
 
 
 class Credentials:
-
-    def __init__(self, refresh_token):
+    def __init__(self, refresh_token, git_access_token):
         self.refresh_token = refresh_token
+        self.git_access_token = git_access_token
 
     @staticmethod
     def from_isi(path: Path = CREDENTIALS_FILE):
@@ -74,7 +74,8 @@ class Credentials:
             raise FileNotFoundError("Create file {path} first.".format(path=path))
         conf = configparser.ConfigParser()
         conf.read(str(path))
-        return Credentials(refresh_token=conf['meeshkan']['token'])
+        return Credentials(refresh_token=conf['meeshkan']['token'],
+                           git_access_token=conf.get('github', 'token', fallback=None))
 
     @staticmethod
     def to_isi(refresh_token: str, path: Path = CREDENTIALS_FILE):
@@ -82,8 +83,11 @@ class Credentials:
         Does not create missing folders along `path`, instead, raises FileNotFound exception.
 
         """
+        prev_credentials = Credentials.from_isi(path)
         with path.open("w") as credential_file:
             credential_file.write("[meeshkan]\ntoken={token}\n".format(token=refresh_token))
+            # Restore Git token (even if None...)
+            credential_file.write("\n[github]\ntoken={token}\n".format(token=prev_credentials.git_access_token))
             credential_file.flush()
 
 

--- a/meeshkan/core/config.py
+++ b/meeshkan/core/config.py
@@ -74,8 +74,8 @@ class Credentials:
             raise FileNotFoundError("Create file {path} first.".format(path=path))
         conf = configparser.ConfigParser()
         conf.read(str(path))
-        return Credentials(refresh_token=conf.get('meeshkan', 'token', fallback=None),
-                           git_access_token=conf.get('github', 'token', fallback=None))
+        return Credentials(refresh_token=conf.get('meeshkan', 'token', fallback=None),  # type: ignore
+                           git_access_token=conf.get('github', 'token', fallback=None))  # type: ignore
 
     @staticmethod
     def to_isi(refresh_token: str = None, git_token: str = None, path: Path = CREDENTIALS_FILE):

--- a/meeshkan/core/config.py
+++ b/meeshkan/core/config.py
@@ -78,7 +78,7 @@ class Credentials:
                            git_access_token=conf.get('github', 'token', fallback=None))
 
     @staticmethod
-    def to_isi(refresh_token: str, path: Path = CREDENTIALS_FILE):
+    def to_isi(refresh_token: str, path: Path = CREDENTIALS_FILE):  # TODO accept Git token as well?
         """Creates the credential file with given refresh token. Overrides previous token if exists.
         Does not create missing folders along `path`, instead, raises FileNotFound exception.
 

--- a/meeshkan/core/config.py
+++ b/meeshkan/core/config.py
@@ -79,17 +79,17 @@ class Credentials:
 
     @staticmethod
     def to_isi(refresh_token: str = None, git_token: str = None, path: Path = CREDENTIALS_FILE):
-        """Creates the credential file with given refresh token. Overrides previous token if exists.
+        """Creates the credential file with given refresh token, git_token or both. Overrides previous token if exists.
         Does not create missing folders along `path`, instead, raises FileNotFound exception.
         """
-        git_token = git_token or Credentials.from_isi(path).git_access_token
-        refresh_token = refresh_token or Credentials.from_isi(path).refresh_token
+        prev_creds = Credentials.from_isi(path)  # Restore from previous if not some arguments are not supplied
+        git_token = git_token or prev_creds.git_access_token
+        refresh_token = refresh_token or prev_creds.refresh_token
         if git_token is None and refresh_token is None:
             raise ValueError("Nothing to write to ISI file.")
 
         with path.open("w") as credential_file:
             credential_file.write("[meeshkan]\ntoken={token}\n".format(token=refresh_token))
-            # Restore Git token (even if None...)
             credential_file.write("\n[github]\ntoken={token}\n".format(token=git_token))
             credential_file.flush()
 

--- a/meeshkan/core/config.py
+++ b/meeshkan/core/config.py
@@ -63,6 +63,8 @@ class Configuration:
 class Credentials:
     def __init__(self, refresh_token, git_access_token):
         self.refresh_token = refresh_token
+        if not git_access_token:
+            git_access_token = None  # Make sure we write None on values such as "", False, None, etc
         self.git_access_token = git_access_token
 
     @staticmethod
@@ -74,23 +76,25 @@ class Credentials:
             raise FileNotFoundError("Create file {path} first.".format(path=path))
         conf = configparser.ConfigParser()
         conf.read(str(path))
-        return Credentials(refresh_token=conf.get('meeshkan', 'token', fallback=None),  # type: ignore
-                           git_access_token=conf.get('github', 'token', fallback=None))  # type: ignore
+        return Credentials(refresh_token=conf.get('meeshkan', 'token', fallback=""),  # type: ignore
+                           git_access_token=conf.get('github', 'token', fallback=""))  # type: ignore
 
     @staticmethod
-    def to_isi(refresh_token: str = None, git_token: str = None, path: Path = CREDENTIALS_FILE):
+    def to_isi(refresh_token: str = None, git_access_token: str = None, path: Path = CREDENTIALS_FILE):
         """Creates the credential file with given refresh token, git_token or both. Overrides previous token if exists.
         Does not create missing folders along `path`, instead, raises FileNotFound exception.
         """
         prev_creds = Credentials.from_isi(path)  # Restore from previous if not some arguments are not supplied
-        git_token = git_token or prev_creds.git_access_token
+        git_access_token = git_access_token or prev_creds.git_access_token
         refresh_token = refresh_token or prev_creds.refresh_token
-        if git_token is None and refresh_token is None:
-            raise ValueError("Nothing to write to ISI file.")
+        if not git_access_token:
+            if refresh_token is None:
+                raise ValueError("Nothing to write to ISI file.")
+            git_access_token = ""  # Make sure we write an empty string if no git_token is given
 
         with path.open("w") as credential_file:
             credential_file.write("[meeshkan]\ntoken={token}\n".format(token=refresh_token))
-            credential_file.write("\n[github]\ntoken={token}\n".format(token=git_token))
+            credential_file.write("\n[github]\ntoken={token}\n".format(token=git_access_token))
             credential_file.flush()
 
 

--- a/meeshkan/git/__init__.py
+++ b/meeshkan/git/__init__.py
@@ -1,4 +1,5 @@
 from .utils import *  # pylint: disable=wildcard-import
+from . import utils
 
 __all__ = utils.__all__
 

--- a/meeshkan/git/__init__.py
+++ b/meeshkan/git/__init__.py
@@ -1,0 +1,5 @@
+from .utils import *  # pylint: disable=wildcard-import
+
+__all__ = utils.__all__
+
+del utils

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -1,9 +1,26 @@
 """Provides utilities for pulling and parsing Git commits"""
 from typing import List
+import base64
+
 from github import Github
 
-__all__ = []  # type: List[str]
+from ..core.config import Credentials
 
-def pull_commit(repo: str, commit: str):
-    pass
+__all__ = ["pull_commit"]  # type: List[str]
 
+def pull_commit(repo: str, commit_sha: str, download_all=False):
+    """"""
+    creds = Credentials.from_isi()  # Basic setup and lookup
+    if creds.git_access_token is None:  # TODO should git token setup also be made available with CLI?
+        raise RuntimeError("Git access token was not found! Please verify ~/.meeshkan/credentials")
+    git = Github(creds.git_access_token)
+    repo = git.get_repo(repo)
+    commit = repo.get_commit(commit_sha)
+    # Get differences between the default branch and that commit.
+    def_branch_last_commit = repo.get_branch(repo.default_branch).commit
+    changed_files = repo.compare(def_branch_last_commit.sha, commit.sha).files
+    for file in changed_files:
+        content_file = repo.get_contents(file.filename, commit.sha)
+        print(file.filename)
+        print(base64.b64decode(content_file.content).decode())
+        print("====================================\n\n\n\n")

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -1,26 +1,64 @@
 """Provides utilities for pulling and parsing Git commits"""
-from typing import List
-import base64
-
-from github import Github
+from typing import Tuple
+import tempfile
+import shutil
+import os
+from subprocess import Popen, PIPE
 
 from ..core.config import Credentials
+from ..core.service import Service
 
-__all__ = ["pull_commit"]  # type: List[str]
+__all__ = ["run_commit", "run_branch"]
 
-def pull_commit(repo: str, commit_sha: str, download_all=False):
-    """"""
+def run_commit(repo: str, commit_sha: str, entry_point: str):
+    _submit_pulled_entrypoint(pull_commit(repo, commit_sha), entry_point)
+
+
+def run_branch(repo, branch, entry_point):
+    _submit_pulled_entrypoint(pull_branch(repo, branch), entry_point)
+
+
+def pull_commit(repo, commit_sha) -> str:
+    url, target_dir = _init_git(repo)
+    proc = Popen(["git", "clone", url, target_dir], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    _wait_and_raise_on_error(proc)
+    proc = Popen(["git", "reset", "--hard", commit_sha], stdout=PIPE, stderr=PIPE, cwd=target_dir,
+                 universal_newlines=True)
+    _wait_and_raise_on_error(proc)
+    return target_dir
+
+def pull_branch(repo, branch) -> str:
+    url, target_dir = _init_git(repo)
+    proc = Popen(["git", "clone", "--single-branch", "--branch", branch, url, target_dir], stdout=PIPE, stderr=PIPE,
+                 universal_newlines=True)
+    _wait_and_raise_on_error(proc)
+    return target_dir
+
+
+def _get_git_access_token() -> str:
     creds = Credentials.from_isi()  # Basic setup and lookup
     if creds.git_access_token is None:  # TODO should git token setup also be made available with CLI?
         raise RuntimeError("Git access token was not found! Please verify ~/.meeshkan/credentials")
-    git = Github(creds.git_access_token)
-    repo = git.get_repo(repo)
-    commit = repo.get_commit(commit_sha)
-    # Get differences between the default branch and that commit.
-    def_branch_last_commit = repo.get_branch(repo.default_branch).commit
-    changed_files = repo.compare(def_branch_last_commit.sha, commit.sha).files
-    for file in changed_files:
-        content_file = repo.get_contents(file.filename, commit.sha)
-        print(file.filename)
-        print(base64.b64decode(content_file.content).decode())
-        print("====================================\n\n\n\n")
+    return creds.git_access_token
+
+
+def _submit_pulled_entrypoint(source_dir, entry_point):  # TODO - add jobname, poll time, etc
+    # TODO - add removal of source_dir after run?
+    Service.api().submit((os.path.join(source_dir, entry_point), ))
+
+
+def _verify_git_exists():
+    if shutil.which("git") is None:
+        raise RuntimeError("'git' is not installed!")
+
+
+def _init_git(repo) -> Tuple[str, str]:
+    _verify_git_exists()
+    token = _get_git_access_token()
+    return "https://{token}:x-oauth-basic@github.com/{repo}".format(token=token, repo=repo), tempfile.mkdtemp()
+
+
+def _wait_and_raise_on_error(proc):
+    if proc.wait() != 0:
+        print(proc.returncode)
+        raise RuntimeError(proc.stderr.read())

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -1,0 +1,9 @@
+"""Provides utilities for pulling and parsing Git commits"""
+from typing import List
+from github import Github
+
+__all__ = []  # type: List[str]
+
+def pull_commit(repo: str, commit: str):
+    pass
+

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -91,22 +91,23 @@ class GitRunner:
     def _git_access_token(credentials: Optional[Union[Path, str]] = None) -> str:
         if config.CREDENTIALS is None:
             config.init_config()
-        # Defaults automatically to the global CREDENTIALS
-        credentials = config.Credentials.from_isi(Path(credentials)) or config.CREDENTIALS  # type: config.Credentials
-        token = credentials.git_access_token
+        if credentials is not None:
+            token = config.Credentials.from_isi(Path(credentials)).git_access_token
+        else:  # Defaults automatically to the global CREDENTIALS
+            token = config.CREDENTIALS.git_access_token  # type: ignore
         if token is None:
-            raise GitRunner.Exception("Git access token was not found! Run 'meeshkan setup' to configure it properly.")
+            raise GitRunner.GitException("Git access token was not found! Run 'meeshkan setup' to configure it properly.")
         return token
 
     @staticmethod
     def _verify_git_exists():
         if shutil.which("git") is None:
-            raise GitRunner.Exception("'git' is not installed!")
+            raise GitRunner.GitException("'git' is not installed!")
 
     @staticmethod
     def _wait_and_raise_on_error(proc):
         if proc.wait() != 0:
             raise RuntimeError(proc.stderr.read())
 
-    class Exception(Exception):
+    class GitException(Exception):
         pass

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -37,7 +37,7 @@ def pull_branch(repo, branch) -> str:
 
 def _get_git_access_token() -> str:
     creds = Credentials.from_isi()  # Basic setup and lookup
-    if creds.git_access_token is None:  # TODO should git token setup also be made available with CLI?
+    if creds.git_access_token is None:
         raise RuntimeError("Git access token was not found! Please verify ~/.meeshkan/credentials")
     return creds.git_access_token
 

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -20,8 +20,9 @@ def submit(repo: str, entry_point: str, branch: str = None, commit_sha: str = No
     :param job_name: Optional name to give to the job
     :param poll_interval: Optional float, how often to poll for changes from job
     """
+    api = Service.api()  # Raise if agent is not running
     source_dir = pull_repo(repo, branch=branch, commit_sha=commit_sha)
-    Service.api().submit((os.path.join(source_dir, entry_point),), name=job_name, poll_interval=poll_interval)
+    api.submit((os.path.join(source_dir, entry_point),), name=job_name, poll_interval=poll_interval)
 
 
 def pull_repo(repo: str, branch: str = None, commit_sha: str = None) -> str:
@@ -51,9 +52,10 @@ def pull_repo(repo: str, branch: str = None, commit_sha: str = None) -> str:
 def _get_git_access_token() -> str:
     if config.CREDENTIALS is None:
         config.init_config()
-    if config.CREDENTIALS.git_access_token is None:
+    token = config.CREDENTIALS.git_access_token  # type: ignore
+    if token is None:
         raise RuntimeError("Git access token was not found! Please verify ~/.meeshkan/credentials")
-    return config.CREDENTIALS.git_access_token
+    return token
 
 
 def _verify_git_exists():

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -49,6 +49,8 @@ def pull_repo(repo: str, branch: str = None, commit_sha: str = None) -> str:
 
 
 def _get_git_access_token() -> str:
+    if config.CREDENTIALS is None:
+        config.init_config()
     if config.CREDENTIALS.git_access_token is None:
         raise RuntimeError("Git access token was not found! Please verify ~/.meeshkan/credentials")
     return config.CREDENTIALS.git_access_token

--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -5,7 +5,7 @@ import shutil
 import os
 from subprocess import Popen, PIPE
 
-from ..core.config import Credentials
+from ..core import config
 from ..core.service import Service
 
 __all__ = ["submit"]
@@ -49,10 +49,9 @@ def pull_repo(repo: str, branch: str = None, commit_sha: str = None) -> str:
 
 
 def _get_git_access_token() -> str:
-    creds = Credentials.from_isi()  # Basic setup and lookup
-    if creds.git_access_token is None:
+    if config.CREDENTIALS.git_access_token is None:
         raise RuntimeError("Git access token was not found! Please verify ~/.meeshkan/credentials")
-    return creds.git_access_token
+    return config.CREDENTIALS.git_access_token
 
 
 def _verify_git_exists():

--- a/tests/resources/.credentials
+++ b/tests/resources/.credentials
@@ -1,2 +1,5 @@
 [meeshkan]
 token=asdf
+
+[github]
+token=ghjk

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from .utils import TempCredentialsFile
 def test_config_init():
     assert meeshkan.config.CONFIG.cloud_url == "http://foo.bar", "Configuration should match yaml file contents"
     assert meeshkan.config.CREDENTIALS.refresh_token == 'asdf', "Credentials should match yaml file contents"
-    assert meeshkan.config.CREDENTIALS.git_access_token is None, "By default no git access token is supplied"
+    assert meeshkan.config.CREDENTIALS.git_access_token == 'ghjk', "Credentials should match yaml file contents"
 
 
 def test_credentials_change_with_error():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,18 +7,61 @@ import tempfile
 def test_config_init():
     assert meeshkan.config.CONFIG.cloud_url == "http://foo.bar", "Configuration should match yaml file contents"
     assert meeshkan.config.CREDENTIALS.refresh_token == 'asdf', "Credentials should match yaml file contents"
+    assert meeshkan.config.CREDENTIALS.git_access_token is None, "By default no git access token is supplied"
+
 
 def test_credentials_change_with_error():
-    non_existing_path = Path(tempfile.gettempdir()).joinpath(next(tempfile._get_candidate_names()))
+    imaginary_path = Path(tempfile.gettempdir()).joinpath(next(tempfile._get_candidate_names()))
     with pytest.raises(FileNotFoundError):
-        meeshkan.config.Credentials.to_isi("abc", non_existing_path.joinpath(next(tempfile._get_candidate_names())))
+        meeshkan.config.Credentials.to_isi("abc", path=imaginary_path.joinpath(next(tempfile._get_candidate_names())))
+
 
 def test_credentials_change_no_error():
-    fid, tmp = tempfile.mkstemp()
+    _, tmp = tempfile.mkstemp()
     tmpfile = Path(tmp)
     refresh_token = "abc"
-    meeshkan.config.Credentials.to_isi(refresh_token, tmpfile)
-    assert_msg = "Credentials should match newly created file with `to_isi` and " \
-                 "refresh token '{}'".format(refresh_token)
-    assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == "abc", assert_msg
-    tmpfile.unlink()  # Cleanup
+    git_token = "def"
+    assert_msg1 = "Credentials should match newly created file with `to_isi` and " \
+                  "refresh token '{}'".format(refresh_token)
+    assert_msg2 = "Credentials should match newly created file with `to_isi` and " \
+                  "git token '{}'".format(git_token)
+    try:
+        meeshkan.config.Credentials.to_isi(refresh_token, git_token=git_token, path=tmpfile)
+        assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == refresh_token, assert_msg1
+        assert meeshkan.config.Credentials.from_isi(tmpfile).git_access_token == git_token, assert_msg2
+    finally:
+        tmpfile.unlink()  # Cleanup
+
+
+def test_credentials_change_without_git():
+    _, tmp = tempfile.mkstemp()
+    tmpfile = Path(tmp)
+    refresh_token = "abc"
+    git_token = "def"
+    new_refresh_token = "def"
+    assert_msg1 = "Git credentials should be maintained if not provided in `to_isi`"
+    assert_msg2 = "Refresh token should be updated if provided in `to_isi`"
+    try:
+        meeshkan.config.Credentials.to_isi(refresh_token, git_token=git_token, path=tmpfile)
+        meeshkan.config.Credentials.to_isi(new_refresh_token, path=tmpfile)
+        assert meeshkan.config.Credentials.from_isi(tmpfile).git_access_token == git_token, assert_msg1
+        assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == new_refresh_token, assert_msg2
+    finally:
+        tmpfile.unlink()
+
+
+def test_credentials_changes_without_token():
+    _, tmp = tempfile.mkstemp()
+    tmpfile = Path(tmp)
+    refresh_token = "abc"
+    git_token = "def"
+    new_git_token = "def"
+    assert_msg1 = "Refresh token should be maintained if not provided in `to_isi`"
+    assert_msg2 = "Git credentials should be updated if provided in `to_isi`"
+    try:
+        meeshkan.config.Credentials.to_isi(refresh_token, git_token=git_token, path=tmpfile)
+        meeshkan.config.Credentials.to_isi(git_token=new_git_token, path=tmpfile)
+        assert meeshkan.config.Credentials.from_isi(tmpfile).git_access_token == new_git_token, assert_msg1
+        assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == refresh_token, assert_msg2
+    finally:
+        tmpfile.unlink()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@ import pytest
 from pathlib import Path
 import tempfile
 
+from .utils import TempCredentialsFile
+
 # Configuration initialized in `tests/__init__.py`
 def test_config_init():
     assert meeshkan.config.CONFIG.cloud_url == "http://foo.bar", "Configuration should match yaml file contents"
@@ -17,51 +19,36 @@ def test_credentials_change_with_error():
 
 
 def test_credentials_change_no_error():
-    _, tmp = tempfile.mkstemp()
-    tmpfile = Path(tmp)
     refresh_token = "abc"
     git_token = "def"
     assert_msg1 = "Credentials should match newly created file with `to_isi` and " \
                   "refresh token '{}'".format(refresh_token)
     assert_msg2 = "Credentials should match newly created file with `to_isi` and " \
                   "git token '{}'".format(git_token)
-    try:
-        meeshkan.config.Credentials.to_isi(refresh_token, git_token=git_token, path=tmpfile)
-        assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == refresh_token, assert_msg1
-        assert meeshkan.config.Credentials.from_isi(tmpfile).git_access_token == git_token, assert_msg2
-    finally:
-        tmpfile.unlink()  # Cleanup
+    with TempCredentialsFile(refresh_token=refresh_token, git_token=git_token) as tmpfile:
+        assert meeshkan.config.Credentials.from_isi(tmpfile.file).refresh_token == refresh_token, assert_msg1
+        assert meeshkan.config.Credentials.from_isi(tmpfile.file).git_access_token == git_token, assert_msg2
 
 
 def test_credentials_change_without_git():
-    _, tmp = tempfile.mkstemp()
-    tmpfile = Path(tmp)
     refresh_token = "abc"
     git_token = "def"
     new_refresh_token = "def"
     assert_msg1 = "Git credentials should be maintained if not provided in `to_isi`"
     assert_msg2 = "Refresh token should be updated if provided in `to_isi`"
-    try:
-        meeshkan.config.Credentials.to_isi(refresh_token, git_token=git_token, path=tmpfile)
-        meeshkan.config.Credentials.to_isi(new_refresh_token, path=tmpfile)
-        assert meeshkan.config.Credentials.from_isi(tmpfile).git_access_token == git_token, assert_msg1
-        assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == new_refresh_token, assert_msg2
-    finally:
-        tmpfile.unlink()
+    with TempCredentialsFile(refresh_token=refresh_token, git_token=git_token) as tmpfile:
+        tmpfile.update(refresh_token=new_refresh_token)
+        assert meeshkan.config.Credentials.from_isi(tmpfile.file).git_access_token == git_token, assert_msg1
+        assert meeshkan.config.Credentials.from_isi(tmpfile.file).refresh_token == new_refresh_token, assert_msg2
 
 
 def test_credentials_changes_without_token():
-    _, tmp = tempfile.mkstemp()
-    tmpfile = Path(tmp)
     refresh_token = "abc"
     git_token = "def"
     new_git_token = "def"
     assert_msg1 = "Refresh token should be maintained if not provided in `to_isi`"
     assert_msg2 = "Git credentials should be updated if provided in `to_isi`"
-    try:
-        meeshkan.config.Credentials.to_isi(refresh_token, git_token=git_token, path=tmpfile)
-        meeshkan.config.Credentials.to_isi(git_token=new_git_token, path=tmpfile)
-        assert meeshkan.config.Credentials.from_isi(tmpfile).git_access_token == new_git_token, assert_msg1
-        assert meeshkan.config.Credentials.from_isi(tmpfile).refresh_token == refresh_token, assert_msg2
-    finally:
-        tmpfile.unlink()
+    with TempCredentialsFile(refresh_token=refresh_token, git_token=git_token) as tmpfile:
+        tmpfile.update(git_token=new_git_token)
+        assert meeshkan.config.Credentials.from_isi(tmpfile.file).git_access_token == new_git_token, assert_msg1
+        assert meeshkan.config.Credentials.from_isi(tmpfile.file).refresh_token == refresh_token, assert_msg2

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -64,16 +64,16 @@ def test_gitrunner_pull_branch(clean):
         clean(gitrunner)
 
 
-# def test_gitrunner_pull_commit(clean):
-#     gitrunner = GitRunner(repo=CLIENT_REPO)
-#     gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
-#     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
-#     try:
-#         assert os.path.isfile(version_fname)
-#         with open(version_fname) as version_fd:
-#             assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
-#     finally:
-#         clean(gitrunner)
+def test_gitrunner_pull_commit(clean):
+    gitrunner = GitRunner(repo=CLIENT_REPO)
+    gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
+    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
+    try:
+        assert os.path.isfile(version_fname)
+        with open(version_fname) as version_fd:
+            assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
+    finally:
+        clean(gitrunner)
 #
 #
 # def test_gitrunner_pull_branch_and_commit(clean):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -74,16 +74,16 @@ def test_gitrunner_pull_commit(clean):
             assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
     finally:
         clean(gitrunner)
-#
-#
-# def test_gitrunner_pull_branch_and_commit(clean):
-#     gitrunner = GitRunner(repo=CLIENT_REPO)
-#     gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
-#     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
-#     try:
-#         assert os.path.isfile(version_fname)
-#         with open(version_fname) as version_fd:
-#             assert version_fd.read() == "__version__ = \"0.0.1\"", "When pulling a commit and a branch, commit SHA is" \
-#                                                                    " expected to take precedence!"
-#     finally:
-#         clean(gitrunner)
+
+
+def test_gitrunner_pull_branch_and_commit(clean):
+    gitrunner = GitRunner(repo=CLIENT_REPO)
+    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
+    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
+    try:
+        assert os.path.isfile(version_fname)
+        with open(version_fname) as version_fd:
+            assert version_fd.read() == "__version__ = \"0.0.1\"", "When pulling a commit and a branch, commit SHA is" \
+                                                                   " expected to take precedence!"
+    finally:
+        clean(gitrunner)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,7 +8,7 @@ from .utils import TempCredentialsFile, wait_for_true
 
 import meeshkan
 from meeshkan.core.service import Service
-import meeshkan.git.utils as mg
+from meeshkan.git.utils import submit_git, GitRunner
 
 CLIENT_REPO = "Meeshkan/meeshkan-client"
 FIRST_VERSION_COMMIT = "cee35e9"  # v0.0.1 psuedo-release
@@ -17,7 +17,7 @@ FIRST_OFFICIAL_RELEASE_BRANCH = "release-v-0.1.0"  # first official release
 
 @pytest.fixture
 def clean():
-    def remove_tempdir_from_gitrunner(gitrunner: mg.GitRunner):
+    def remove_tempdir_from_gitrunner(gitrunner: GitRunner):
         shutil.rmtree(gitrunner.target_dir)
     return remove_tempdir_from_gitrunner
 
@@ -28,23 +28,23 @@ def test_git_verify():
         return "fake_address" if git_exists else None
 
     with mock.patch("shutil.which", fake_which):
-        with pytest.raises(mg.GitRunner.GitException):
-            mg.GitRunner._verify_git_exists()
+        with pytest.raises(GitRunner.GitException):
+            GitRunner._verify_git_exists()
         git_exists = True
-        mg.GitRunner._verify_git_exists()
+        GitRunner._verify_git_exists()
 
 
 def test_git_access_token():
     with TempCredentialsFile(refresh_token="fake") as tmpfile:
-        with pytest.raises(mg.GitRunner.GitException):
-            mg.GitRunner._git_access_token(tmpfile.file), "Default test credentials do not contain a github token!"
+        with pytest.raises(GitRunner.GitException):
+            GitRunner._git_access_token(tmpfile.file), "Default test credentials do not contain a github token!"
         tmpfile.update(git_token="abc")
-        assert mg.GitRunner._git_access_token(tmpfile.file) == "abc"
+        assert GitRunner._git_access_token(tmpfile.file) == "abc"
 
 
 def test_gitrunner_init(clean):
     repo = "foobar"
-    gitrunner = mg.GitRunner(repo=repo)
+    gitrunner = GitRunner(repo=repo)
     git_token = meeshkan.config.CREDENTIALS.git_access_token
     try:
         assert gitrunner.url == "https://{token}:x-oauth-basic@github.com/{repo}".format(token=git_token, repo=repo)
@@ -53,7 +53,7 @@ def test_gitrunner_init(clean):
 
 
 def test_gitrunner_pull_branch(clean):
-    gitrunner = mg.GitRunner(repo=CLIENT_REPO)
+    gitrunner = GitRunner(repo=CLIENT_REPO)
     gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
     version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
     try:
@@ -65,7 +65,7 @@ def test_gitrunner_pull_branch(clean):
 
 
 def test_gitrunner_pull_commit(clean):
-    gitrunner = mg.GitRunner(repo=CLIENT_REPO)
+    gitrunner = GitRunner(repo=CLIENT_REPO)
     gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
     try:
@@ -77,7 +77,7 @@ def test_gitrunner_pull_commit(clean):
 
 
 def test_gitrunner_pull_branch_and_commit(clean):
-    gitrunner = mg.GitRunner(repo=CLIENT_REPO)
+    gitrunner = GitRunner(repo=CLIENT_REPO)
     gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
     try:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest import mock
+from pathlib import Path
+import shutil
+import os
+
+from .utils import TempCredentialsFile, wait_for_true
+
+import meeshkan
+from meeshkan.core.service import Service
+import meeshkan.git.utils as mg
+
+CLIENT_REPO = "Meeshkan/meeshkan-client"
+FIRST_VERSION_COMMIT = "cee35e9"  # v0.0.1 psuedo-release
+FIRST_OFFICIAL_RELEASE_BRANCH = "release-v-0.1.0"  # first official release
+
+
+@pytest.fixture
+def clean():
+    def remove_tempdir_from_gitrunner(gitrunner: mg.GitRunner):
+        shutil.rmtree(gitrunner.target_dir)
+    return remove_tempdir_from_gitrunner
+
+
+def test_git_verify():
+    git_exists = False
+    def fake_which(*args, **kwargs):
+        return "fake_address" if git_exists else None
+
+    with mock.patch("shutil.which", fake_which):
+        with pytest.raises(mg.GitRunner.GitException):
+            mg.GitRunner._verify_git_exists()
+        git_exists = True
+        mg.GitRunner._verify_git_exists()
+
+
+def test_git_access_token():
+    with TempCredentialsFile(refresh_token="fake") as tmpfile:
+        with pytest.raises(mg.GitRunner.GitException):
+            mg.GitRunner._git_access_token(tmpfile.file), "Default test credentials do not contain a github token!"
+        tmpfile.update(git_token="abc")
+        assert mg.GitRunner._git_access_token(tmpfile.file) == "abc"
+
+
+def test_gitrunner_init(clean):
+    repo = "foobar"
+    gitrunner = mg.GitRunner(repo=repo)
+    git_token = meeshkan.config.CREDENTIALS.git_access_token
+    try:
+        assert gitrunner.url == "https://{token}:x-oauth-basic@github.com/{repo}".format(token=git_token, repo=repo)
+    finally:
+        clean(gitrunner)
+
+
+def test_gitrunner_pull_branch(clean):
+    gitrunner = mg.GitRunner(repo=CLIENT_REPO)
+    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
+    version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
+    try:
+        assert os.path.isfile(version_fname)
+        with open(version_fname) as version_fd:
+            assert version_fd.read() == "__version__ = '0.1.0'\n"
+    finally:
+        clean(gitrunner)
+
+
+def test_gitrunner_pull_commit(clean):
+    gitrunner = mg.GitRunner(repo=CLIENT_REPO)
+    gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
+    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
+    try:
+        assert os.path.isfile(version_fname)
+        with open(version_fname) as version_fd:
+            assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
+    finally:
+        clean(gitrunner)
+
+
+def test_gitrunner_pull_branch_and_commit(clean):
+    gitrunner = mg.GitRunner(repo=CLIENT_REPO)
+    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
+    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
+    try:
+        assert os.path.isfile(version_fname)
+        with open(version_fname) as version_fd:
+            assert version_fd.read() == "__version__ = \"0.0.1\"", "When pulling a commit and a branch, commit SHA is" \
+                                                                   " expected to take precedence!"
+    finally:
+        clean(gitrunner)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -10,16 +10,16 @@ import meeshkan
 from meeshkan.core.service import Service
 from meeshkan.git.utils import submit_git, GitRunner
 
-# CLIENT_REPO = "Meeshkan/meeshkan-client"
-# FIRST_VERSION_COMMIT = "cee35e9"  # v0.0.1 psuedo-release
-# FIRST_OFFICIAL_RELEASE_BRANCH = "release-v-0.1.0"  # first official release
+CLIENT_REPO = "Meeshkan/meeshkan-client"
+FIRST_VERSION_COMMIT = "cee35e9"  # v0.0.1 psuedo-release
+FIRST_OFFICIAL_RELEASE_BRANCH = "release-v-0.1.0"  # first official release
 
 
-# @pytest.fixture
-# def clean():
-#     def remove_tempdir_from_gitrunner(gitrunner: GitRunner):
-#         shutil.rmtree(gitrunner.target_dir)
-#     return remove_tempdir_from_gitrunner
+@pytest.fixture
+def clean():
+    def remove_tempdir_from_gitrunner(gitrunner: GitRunner):
+        shutil.rmtree(gitrunner.target_dir)
+    return remove_tempdir_from_gitrunner
 
 
 def test_git_verify():
@@ -42,28 +42,28 @@ def test_git_access_token():
         assert GitRunner._git_access_token(tmpfile.file) == "abc"
 
 
-# def test_gitrunner_init(clean):
-#     repo = "foobar"
-#     gitrunner = GitRunner(repo=repo)
-#     git_token = meeshkan.config.CREDENTIALS.git_access_token
-#     try:
-#         assert gitrunner.url == "https://{token}:x-oauth-basic@github.com/{repo}".format(token=git_token, repo=repo)
-#     finally:
-#         clean(gitrunner)
+def test_gitrunner_init(clean):
+    repo = "foobar"
+    gitrunner = GitRunner(repo=repo)
+    git_token = meeshkan.config.CREDENTIALS.git_access_token
+    try:
+        assert gitrunner.url == "https://{token}:x-oauth-basic@github.com/{repo}".format(token=git_token, repo=repo)
+    finally:
+        clean(gitrunner)
 
 
-# def test_gitrunner_pull_branch(clean):
-#     gitrunner = GitRunner(repo=CLIENT_REPO)
-#     gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
-#     version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
-#     try:
-#         assert os.path.isfile(version_fname)
-#         with open(version_fname) as version_fd:
-#             assert version_fd.read() == "__version__ = '0.1.0'\n"
-#     finally:
-#         clean(gitrunner)
-#
-#
+def test_gitrunner_pull_branch(clean):
+    gitrunner = GitRunner(repo=CLIENT_REPO)
+    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
+    version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
+    try:
+        assert os.path.isfile(version_fname)
+        with open(version_fname) as version_fd:
+            assert version_fd.read() == "__version__ = '0.1.0'\n"
+    finally:
+        clean(gitrunner)
+
+
 # def test_gitrunner_pull_commit(clean):
 #     gitrunner = GitRunner(repo=CLIENT_REPO)
 #     gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -10,16 +10,16 @@ import meeshkan
 from meeshkan.core.service import Service
 from meeshkan.git.utils import submit_git, GitRunner
 
-CLIENT_REPO = "Meeshkan/meeshkan-client"
-FIRST_VERSION_COMMIT = "cee35e9"  # v0.0.1 psuedo-release
-FIRST_OFFICIAL_RELEASE_BRANCH = "release-v-0.1.0"  # first official release
+# CLIENT_REPO = "Meeshkan/meeshkan-client"
+# FIRST_VERSION_COMMIT = "cee35e9"  # v0.0.1 psuedo-release
+# FIRST_OFFICIAL_RELEASE_BRANCH = "release-v-0.1.0"  # first official release
 
 
-@pytest.fixture
-def clean():
-    def remove_tempdir_from_gitrunner(gitrunner: GitRunner):
-        shutil.rmtree(gitrunner.target_dir)
-    return remove_tempdir_from_gitrunner
+# @pytest.fixture
+# def clean():
+#     def remove_tempdir_from_gitrunner(gitrunner: GitRunner):
+#         shutil.rmtree(gitrunner.target_dir)
+#     return remove_tempdir_from_gitrunner
 
 
 def test_git_verify():
@@ -42,48 +42,48 @@ def test_git_access_token():
         assert GitRunner._git_access_token(tmpfile.file) == "abc"
 
 
-def test_gitrunner_init(clean):
-    repo = "foobar"
-    gitrunner = GitRunner(repo=repo)
-    git_token = meeshkan.config.CREDENTIALS.git_access_token
-    try:
-        assert gitrunner.url == "https://{token}:x-oauth-basic@github.com/{repo}".format(token=git_token, repo=repo)
-    finally:
-        clean(gitrunner)
+# def test_gitrunner_init(clean):
+#     repo = "foobar"
+#     gitrunner = GitRunner(repo=repo)
+#     git_token = meeshkan.config.CREDENTIALS.git_access_token
+#     try:
+#         assert gitrunner.url == "https://{token}:x-oauth-basic@github.com/{repo}".format(token=git_token, repo=repo)
+#     finally:
+#         clean(gitrunner)
 
 
-def test_gitrunner_pull_branch(clean):
-    gitrunner = GitRunner(repo=CLIENT_REPO)
-    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
-    version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
-    try:
-        assert os.path.isfile(version_fname)
-        with open(version_fname) as version_fd:
-            assert version_fd.read() == "__version__ = '0.1.0'\n"
-    finally:
-        clean(gitrunner)
-
-
-def test_gitrunner_pull_commit(clean):
-    gitrunner = GitRunner(repo=CLIENT_REPO)
-    gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
-    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
-    try:
-        assert os.path.isfile(version_fname)
-        with open(version_fname) as version_fd:
-            assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
-    finally:
-        clean(gitrunner)
-
-
-def test_gitrunner_pull_branch_and_commit(clean):
-    gitrunner = GitRunner(repo=CLIENT_REPO)
-    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
-    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
-    try:
-        assert os.path.isfile(version_fname)
-        with open(version_fname) as version_fd:
-            assert version_fd.read() == "__version__ = \"0.0.1\"", "When pulling a commit and a branch, commit SHA is" \
-                                                                   " expected to take precedence!"
-    finally:
-        clean(gitrunner)
+# def test_gitrunner_pull_branch(clean):
+#     gitrunner = GitRunner(repo=CLIENT_REPO)
+#     gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
+#     version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
+#     try:
+#         assert os.path.isfile(version_fname)
+#         with open(version_fname) as version_fd:
+#             assert version_fd.read() == "__version__ = '0.1.0'\n"
+#     finally:
+#         clean(gitrunner)
+#
+#
+# def test_gitrunner_pull_commit(clean):
+#     gitrunner = GitRunner(repo=CLIENT_REPO)
+#     gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
+#     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
+#     try:
+#         assert os.path.isfile(version_fname)
+#         with open(version_fname) as version_fd:
+#             assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
+#     finally:
+#         clean(gitrunner)
+#
+#
+# def test_gitrunner_pull_branch_and_commit(clean):
+#     gitrunner = GitRunner(repo=CLIENT_REPO)
+#     gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
+#     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
+#     try:
+#         assert os.path.isfile(version_fname)
+#         with open(version_fname) as version_fd:
+#             assert version_fd.read() == "__version__ = \"0.0.1\"", "When pulling a commit and a branch, commit SHA is" \
+#                                                                    " expected to take precedence!"
+#     finally:
+#         clean(gitrunner)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,12 +54,14 @@ def pre_post_tests():
 
 
 def test_setup_if_exists(pre_post_tests):  # pylint:disable=unused-argument,redefined-outer-name
-    """Tests `meeshkan setup` if the credentials file exists"""
+    """Tests `meeshkan setup` if the credentials file exists
+    Does not test wrt to Git access token; that's tested separately in test_config"""
     # Mock credentials writing (tested in test_config.py)
     temp_token = "abc"
 
-    def to_isi(refresh_token, *args):
+    def to_isi(refresh_token, git_token, *args):
         assert refresh_token == temp_token, "Refresh token token used is '{}'!".format(temp_token)
+        assert git_token == "", "No git access token is given!"
 
     with mock.patch("meeshkan.config.Credentials.to_isi") as mock_to_isi:
         with mock.patch("os.path.isfile") as mock_isfile:
@@ -67,39 +69,41 @@ def test_setup_if_exists(pre_post_tests):  # pylint:disable=unused-argument,rede
             mock_to_isi.side_effect = to_isi
 
             # Test with proper interaction
-            run_cli(args=['setup'], inputs="y\n{token}\n".format(token=temp_token), catch_exceptions=False)
+            run_cli(args=['setup'], inputs="y\n{token}\n\n".format(token=temp_token), catch_exceptions=False)
             assert mock_to_isi.call_count == 1, "`to_isi` should only be called once (proper response)"
 
             # Test with empty response
-            run_cli(args=['setup'], inputs="\n{token}\n".format(token=temp_token), catch_exceptions=False)
+            run_cli(args=['setup'], inputs="\n{token}\n\n".format(token=temp_token), catch_exceptions=False)
             assert mock_to_isi.call_count == 2, "`to_isi` should be called twice here (default response)"
 
             # Test with non-positive answer
-            config_result = run_cli(args=['setup'], inputs="asdasdas\n{token}\n".format(token=temp_token),
+            config_result = run_cli(args=['setup'], inputs="asdasdas\n{token}\n\n".format(token=temp_token),
                                     catch_exceptions=False)
             assert mock_to_isi.call_count == 2, "`to_isi` should still be called only twice (negative answer)"
             assert config_result.exit_code == 2, "Exit code should be non-zero (2 - cancelled by user)"
 
 
 def test_setup_if_doesnt_exists(pre_post_tests):  # pylint:disable=unused-argument,redefined-outer-name
-    """Tests `meeshkan setup` if the credentials file does not exist"""
+    """Tests `meeshkan setup` if the credentials file does not exist
+    Does not test wrt to Git access token; that's tested separately in test_config"""
     # Mock credentials writing (tested in test_config.py)
     temp_token = "abc"
 
-    def to_isi(refresh_token, *args):
+    def to_isi(refresh_token, git_token, *args):
         assert refresh_token == temp_token, "Refresh token token used is '{}'!".format(temp_token)
+        assert git_token == "", "No git access token is given!"
 
     with mock.patch("meeshkan.config.Credentials.to_isi") as mock_to_isi:
         with mock.patch("os.path.isfile") as mock_isfile:
             mock_isfile.return_value = False
             mock_to_isi.side_effect = to_isi
             # Test with proper interaction
-            run_cli(args=['setup'], inputs="{token}\n".format(token=temp_token), catch_exceptions=False)
+            run_cli(args=['setup'], inputs="{token}\n\n".format(token=temp_token), catch_exceptions=False)
             assert mock_to_isi.call_count == 1, "`to_isi` should only be called once (token given)"
 
             # Test with empty response
             temp_token = ''
-            run_cli(args=['setup'], inputs="\n", catch_exceptions=False)
+            run_cli(args=['setup'], inputs="\n\n", catch_exceptions=False)
             assert mock_to_isi.call_count == 2, "`to_isi` should be called twice here (empty token)"
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,9 +59,9 @@ def test_setup_if_exists(pre_post_tests):  # pylint:disable=unused-argument,rede
     # Mock credentials writing (tested in test_config.py)
     temp_token = "abc"
 
-    def to_isi(refresh_token, git_token, *args):
+    def to_isi(refresh_token, git_access_token, *args):
         assert refresh_token == temp_token, "Refresh token token used is '{}'!".format(temp_token)
-        assert git_token == "", "No git access token is given!"
+        assert git_access_token == "", "No git access token is given!"
 
     with mock.patch("meeshkan.config.Credentials.to_isi") as mock_to_isi:
         with mock.patch("os.path.isfile") as mock_isfile:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,9 +89,9 @@ def test_setup_if_doesnt_exists(pre_post_tests):  # pylint:disable=unused-argume
     # Mock credentials writing (tested in test_config.py)
     temp_token = "abc"
 
-    def to_isi(refresh_token, git_token, *args):
+    def to_isi(refresh_token, git_access_token, *args):
         assert refresh_token == temp_token, "Refresh token token used is '{}'!".format(temp_token)
-        assert git_token == "", "No git access token is given!"
+        assert git_access_token == "", "No git access token is given!"
 
     with mock.patch("meeshkan.config.Credentials.to_isi") as mock_to_isi:
         with mock.patch("os.path.isfile") as mock_isfile:


### PR DESCRIPTION
Basic integration with Github using `git`. Adds `submit_git` to top-level package. No CLI command for now, under the assumption that if the user has access to local machine (with the agent), then they can clone locally as well.
This branch also updates `config` to include `git_access_token` and matching tests.
Future PRs will eventually implement and allow running jobs from CLI and by polling a matching `Task` from Slack.

- [x] Updates to `credentials`
- [x] Add tests
- [x] Update README
- [x] Add documentation