### PR TITLE
Raise exception in Service.api() if not available

### DIFF
--- a/meeshkan/__utils__.py
+++ b/meeshkan/__utils__.py
@@ -29,10 +29,11 @@ def save_token(token: str):
 
 
 def _get_api() -> Api:
-    if not Service.is_running():
-        print("Start the service first.")
-        raise AgentNotAvailableException()
-    api = Service.api()  # type: Api
+    try:
+        api = Service.api()  # type: Api
+    except AgentNotAvailableException:
+        print("Start the agent first.")
+        raise
     return api
 
 

--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -106,10 +106,12 @@ def start() -> bool:
     config, credentials = __utils__.get_auth()
 
     cloud_client = __utils__._build_cloud_client(config, credentials)  # pylint: disable=protected-access
-    cloud_client.notify_service_start()
-    cloud_client_serialized = Serializer.serialize(cloud_client)
-    Service.start(cloud_client_serialized=cloud_client_serialized)
-    cloud_client.close()
+    try:
+        cloud_client.notify_service_start()
+        cloud_client_serialized = Serializer.serialize(cloud_client)
+        Service.start(cloud_client_serialized=cloud_client_serialized)
+    finally:
+        cloud_client.close()
 
     print('Service started.')
     return True

--- a/meeshkan/agent.py
+++ b/meeshkan/agent.py
@@ -92,22 +92,24 @@ def restart():
     start()
 
 
-def start() -> str:
-    """Start the agent.
+def start() -> bool:
+    """
+    Start the Meeshkan agent.
 
-    :return str: Pyro server URI.
+    :return bool: True if agent was started, False if agent was already running.
     """
     __verify_version()
     if is_running():
         print("Service is already running.")
-        return Service.URI
+        return False
 
     config, credentials = __utils__.get_auth()
 
     cloud_client = __utils__._build_cloud_client(config, credentials)  # pylint: disable=protected-access
     cloud_client.notify_service_start()
     cloud_client_serialized = Serializer.serialize(cloud_client)
-    pyro_uri = Service.start(cloud_client_serialized=cloud_client_serialized)
-    print('Service started.')
+    Service.start(cloud_client_serialized=cloud_client_serialized)
     cloud_client.close()
-    return pyro_uri
+
+    print('Service started.')
+    return True

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -165,11 +165,8 @@ class Service:
                 raise RuntimeError("Terminate daemon event does not exist. "
                                    "The stop() method may have called from the wrong process.")
             self.terminate_daemon_event.set()  # Flag for requestLoop to terminate
-            try:
-                with Service._pyro_proxy() as pyro_proxy:
-                    # triggers checking loopCondition
-                    pyro_proxy._pyroBind()  # pylint: disable=protected-acces
-            except AgentNotAvailableException:
-                pass
+            with Service._pyro_proxy() as pyro_proxy:
+                # triggers checking loopCondition
+                pyro_proxy._pyroBind()  # pylint: disable=protected-acces
             return True
         return False

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -14,6 +14,7 @@ import Pyro4  # For daemon management
 from .logger import remove_non_file_handlers
 from ..__build__ import _build_api
 from .serializer import Serializer
+from ..exceptions import AgentNotAvailableException
 
 LOGGER = logging.getLogger(__name__)
 DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
@@ -55,7 +56,7 @@ class Service:
         """Checks whether the daemon is running on localhost.
         Assumes the port is either taken by Pyro or is free.
         """
-        with Pyro4.Proxy(Service.URI) as pyro_proxy:
+        with Service._pyro_proxy() as pyro_proxy:
             try:
                 pyro_proxy._pyroBind()  # pylint: disable=protected-access
                 return True
@@ -64,6 +65,23 @@ class Service:
 
     @staticmethod
     def api() -> Pyro4.Proxy:
+        """
+        Get Pyro proxy for the agent API.
+
+        :raises AgentNotAvailableException: If agent is not running.
+        :return: Pyro proxy.
+        """
+        if not Service.is_running():
+            raise AgentNotAvailableException()
+        return Service._pyro_proxy()
+
+    @staticmethod
+    def _pyro_proxy():
+        """
+        Get Pyro proxy. Does not check proxy is available.
+
+        :return: Pyro proxy.
+        """
         return Pyro4.Proxy(Service.URI)
 
     @staticmethod
@@ -147,8 +165,11 @@ class Service:
                 raise RuntimeError("Terminate daemon event does not exist. "
                                    "The stop() method may have called from the wrong process.")
             self.terminate_daemon_event.set()  # Flag for requestLoop to terminate
-            with Service.api() as pyro_proxy:
-                # triggers checking loopCondition
-                pyro_proxy._pyroBind()  # pylint: disable=protected-access
+            try:
+                with Service._pyro_proxy() as pyro_proxy:
+                    # triggers checking loopCondition
+                    pyro_proxy._pyroBind()  # pylint: disable=protected-acces
+            except AgentNotAvailableException:
+                pass
             return True
         return False

--- a/meeshkan/sagemaker/lib.py
+++ b/meeshkan/sagemaker/lib.py
@@ -7,6 +7,7 @@ from ..core.job import SageMakerJob
 
 __all__ = ["monitor"]  # type: List[str]
 
+
 def monitor(job_name: str, poll_interval: Optional[float] = None):
     """
     Start monitoring a SageMaker training job.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,4 +1,5 @@
 import pytest
+from meeshkan.exceptions import AgentNotAvailableException
 from meeshkan.core.service import Service
 from meeshkan.core.serializer import Serializer
 from .utils import PicklableMock
@@ -13,18 +14,29 @@ def stop_if_running():
         with Service.api() as api:
             api.stop()
 
-            
-def test_start_stop(mock_cloud_client):  # pylint:disable=redefined-outer-name
-    Service.start(Serializer.serialize(mock_cloud_client))
-    assert Service.is_running()
+
+@pytest.fixture
+def start_stop_agent():
+    stop_if_running()
+    assert not Service.is_running()
+    yield
     stop_if_running()
     assert not Service.is_running()
 
 
-def test_double_start(mock_cloud_client):  # pylint:disable=redefined-outer-name
+def test_start_stop(start_stop_agent, mock_cloud_client):  # pylint:disable=redefined-outer-name
+    Service.start(Serializer.serialize(mock_cloud_client))
+    assert Service.is_running()
+
+
+def test_double_start(start_stop_agent, mock_cloud_client):  # pylint:disable=redefined-outer-name
     Service.start(Serializer.serialize(mock_cloud_client))
     assert Service.is_running()
     with pytest.raises(RuntimeError):
         Service.start(Serializer.serialize(mock_cloud_client))
-    stop_if_running()
+
+
+def test_getting_api_before_start_raises_exception():  # pylint:disable=redefined-outer-name
     assert not Service.is_running()
+    with pytest.raises(AgentNotAvailableException):
+        Service.api()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -32,8 +32,10 @@ def test_start_stop(start_stop_agent, mock_cloud_client):  # pylint:disable=rede
 def test_double_start(start_stop_agent, mock_cloud_client):  # pylint:disable=redefined-outer-name
     Service.start(Serializer.serialize(mock_cloud_client))
     assert Service.is_running()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         Service.start(Serializer.serialize(mock_cloud_client))
+
+    assert "Running already" in str(excinfo.value)
 
 
 def test_getting_api_before_start_raises_exception():  # pylint:disable=redefined-outer-name


### PR DESCRIPTION
- Change `Service.api()` to raise `AgentNotAvailableException` as all library methods are using it and it would make sense for them all to raise (or catch) that.
- Change `meeshkan.start()` to return Boolean instead of Pyro URI, I cannot imagine any reason why users would need that
- I think it still makes sense for `__get_api()` to exist as that's used by CLI methods.
- Slightly refactor the `start` method to ensure we don't leak any resources when starting the agent fails.