### PR TITLE
Add quick start in docs.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,19 +3,27 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+=======================================================================
 Meeshkan - Monitoring and remote-control tool for machine learning jobs
 =======================================================================
-**meeshkan** is a Python package providing control to your machine learning jobs.
+
+``meeshkan`` is a Python package providing control to your machine learning jobs.
 
 Main Features
 -------------
-Here are just a few of the things meeshkan can do:
+
+Here are just a few of the things ``meeshkan`` can do:
+
   - Notify you of your job's progress at fixed intervals.
   - Notify you when certain events happen
+  - Schedule machine learning jobs for execution
   - Allow you to control training jobs remotely
   - Allow monitoring Amazon SageMaker jobs
 
-Usage as Python library
+.. include:: ./quick-start.rst
+
+=======================
+Meeshkan Python library
 =======================
 
 .. automodule:: meeshkan
@@ -26,6 +34,7 @@ Usage as Python library
    :members:
    :undoc-members:
 
+======================
 Command-line interface
 ======================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,9 +22,9 @@ Here are just a few of the things ``meeshkan`` can do:
 
 .. include:: ./quick-start.rst
 
-=======================
-Meeshkan Python library
-=======================
+===================
+Meeshkan Python API
+===================
 
 .. automodule:: meeshkan
    :members:

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -1,0 +1,118 @@
+===========
+Quick start
+===========
+
+We recommend running all command-line commands below in a new `Python virtual environment <https://virtualenv.pypa.io/en/latest/>`_.
+
+Sign-up
+-------
+
+Sign up at `meeshkan.com <https://www.meeshkan.com>`_ and you will get your **API key**, also referred to as *token*.
+
+Installation
+------------
+
+Install ``meeshkan`` with `pip <https://pip.pypa.io/en/stable/installing/>`_::
+
+    $ pip install meeshkan
+
+
+If install fails, your Python version may be too old. Please try again with **Python >= 3.6.2**.
+
+Setup
+-----
+
+Setup your credentials::
+
+    $ meeshkan setup
+
+You are prompted for your **API key** that you should have received when signing up, so fill that in.
+The command creates the folder ``.meeshkan`` in your home directory. The folder contains your credentials, agent logs
+and outputs from your submitted jobs.
+
+Start the agent::
+
+    $ meeshkan start
+
+If starting the agent fails, check that your credentials are properly setup. Also check `known issues <https://github.com/Meeshkan/meeshkan-client/#known-issues>`_.
+
+Running jobs from the command line
+----------------------------------
+
+Download example script called `report.py <https://raw.githubusercontent.com/Meeshkan/meeshkan-client/dev/examples/report.py>`_
+from `meeshkan-client <https://github.com/Meeshkan/meeshkan-client/tree/dev/examples) repository to your current directory>`_::
+
+    $ wget https://raw.githubusercontent.com/Meeshkan/meeshkan-client/dev/examples/report.py
+
+The script uses :py:func:`meeshkan.report_scalar` to report scalar values to the agent. These values are included
+in the job notifications sent at fixed intervals.
+
+Submit the example job with 10 second reporting interval::
+
+    $ meeshkan submit --name report-example --report-interval 10 report.py
+
+The command schedules the script for execution. As there is nothing else in the queue, execution starts immediately.
+
+If you setup Slack integration at `meeshkan.com <https://www.meeshkan.com>`_,
+you should receive a notification for job being started. You should get notifications every ten seconds. The script
+runs for 20 seconds, so you should get one notification containing scalar values.
+
+The script uses :py:func:`meeshkan.report_scalar` to report scalar values to the agent.
+These scalar values are included in the job notifications sent at fixed intervals.
+
+You can list the submitted jobs with::
+
+    $ meeshkan list
+
+Retrieve logs for the job named ``report-example``::
+
+    $ meeshkan logs report-example
+
+
+Stop the agent::
+
+    $ meeshkan stop
+
+
+Running jobs from Python
+------------------------
+
+Download example script called `blocking_job.py <https://raw.githubusercontent.com/Meeshkan/meeshkan-client/dev/examples/blocking_job.py>`_::
+
+    $ wget https://raw.githubusercontent.com/Meeshkan/meeshkan-client/dev/examples/blocking_job.py
+
+Execute the script::
+
+    $ python blocking_job.py
+
+If you setup Slack integration at `meeshkan.com <https://www.meeshkan.com>`_, you should again receive a notification
+for a job being started.
+
+Note that unlike ``meeshkan submit`` used above, this example uses :py:func:`meeshkan.as_blocking_job` to
+notify Meeshkan agent of the job context. The decorated function is executed immediately in the calling process,
+thereby blocking the terminal until the script finishes execution.
+Running blocking jobs in this manner is a simple way to run Python scripts with Meeshkan notifications if you do
+not need the agent's scheduling capabilities.
+
+
+PyTorch example
+---------------
+
+You can use Meeshkan with any Python machine learning framework. As an example, let us use PyTorch to train a
+convolution neural network on MNIST.
+
+First install ``torch`` and ``torchvision``::
+
+    $ pip install torch torchvision
+
+Then download the `PyTorch example <https://github.com/Meeshkan/meeshkan-client/blob/dev/examples/pytorch_mnist.py>`_::
+
+    $ wget https://raw.githubusercontent.com/Meeshkan/meeshkan-client/dev/examples/pytorch_mnist.py
+
+Ensure that the agent is running::
+
+    $ meeshkan start
+
+Submit the PyTorch example with a one-minute report interval::
+
+    $ meeshkan submit --name pytorch-example --report-interval 60 pytorch_mnist.py

--- a/meeshkan/sagemaker/lib.py
+++ b/meeshkan/sagemaker/lib.py
@@ -36,4 +36,3 @@ def monitor(job_name: str, poll_interval: Optional[float] = None):
         else:
             print("Started monitoring job {job_name}, "
                   "currently in phase {status}".format(job_name=sagemaker_job.name, status=sagemaker_job.status.name))
-        return

--- a/meeshkan/sagemaker/lib.py
+++ b/meeshkan/sagemaker/lib.py
@@ -10,11 +10,23 @@ __all__ = ["monitor"]  # type: List[str]
 
 def monitor(job_name: str, poll_interval: Optional[float] = None):
     """
-    Start monitoring a SageMaker training job.
+    Start monitoring a SageMaker training job. Requires the agent to be running.
+
+    The agent periodically reads the metrics reported by the job from the SageMaker API and
+    sends Meeshkan notifications.
+
+    Requires ``sagemaker`` Python SDK to be installed. The required AWS credentials are automatically read using
+    the standard
+    `Boto credential chain <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_.
+
+    Example::
+
+        job_name = "sagemaker-job"
+        sagemaker_estimator.fit({'training': inputs}, job_name=job_name, wait=False)
+        meeshkan.sagemaker.monitor(job_name=job_name, poll_interval=600)
 
     :param job_name: SageMaker training job name
     :param poll_interval: Polling interval in seconds, optional. Defaults to one hour.
-    :return: SageMakerJob instance
     """
     with Service.api() as proxy:
         sagemaker_job = proxy.monitor_sagemaker(job_name=job_name, poll_interval=poll_interval)  # type: SageMakerJob
@@ -24,4 +36,4 @@ def monitor(job_name: str, poll_interval: Optional[float] = None):
         else:
             print("Started monitoring job {job_name}, "
                   "currently in phase {status}".format(job_name=sagemaker_job.name, status=sagemaker_job.status.name))
-        return sagemaker_job
+        return


### PR DESCRIPTION
There will be some overlap with `README.md` during migration period, the target is to have the documentation finally in one-place in RTD. The README.md in GitHub should link to ReadTheDocs and only have developer-level information. 
- Also added documentation for `sagemaker.monitor` and changed it to return nothing for now. Might be cool to be able to do stuff like `job.cancel()` in the future with it, but not working atm.