### PR TITLE
Adds `submit_notebook` to user facing API

### DIFF
--- a/meeshkan/api/__init__.py
+++ b/meeshkan/api/__init__.py
@@ -7,7 +7,7 @@ from .scalars import *  # pylint: disable=wildcard-import
 from . import utils
 from .utils import *  # pylint: disable=wildcard-import
 from . import external_job
-from .external_job import *
+from .external_job import *  # pylint: disable=wildcard-import
 
 __all__ = scalars.__all__
 __all__ += conditions.__all__

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -49,8 +49,7 @@ def submit_notebook(job_name: str = None, poll_interval: Optional[float] = None,
         for nb_sess in nb_sessions:
             if nb_sess['kernel']['id'] == kernel_id:
                 path = os.path.join(srv['notebook_dir'], nb_sess['notebook']['path'])
-                Service.api().submit((path,), name=job_name, poll_interval=poll_interval)  # Submit notebook
-                return  # Stops looping
+                return Service.api().submit((path,), name=job_name, poll_interval=poll_interval)  # Submit notebook
 
 
 def _notebook_authenticated_session_or_none(base_url: str, uses_password: bool, port: int,

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -1,21 +1,19 @@
-from typing import List
 import os
 import ipykernel
 from notebook import notebookapp
 import requests
-import json
 
 from ..__utils__ import _get_api
 
-__all__ = ["run_notebook"]  # type: List[str]
+__all__ = ["run_notebook"]
 
 
 def run_notebook():
-    try:
-        ip = get_ipython()  # Verifies this was run in Jupyter
+    try:  # Verifies this was run in an IPython with a non-terminal kernel
+        ip = get_ipython()
         if ip.__class__.__name__ != "ZMQInteractiveShell":  # Used for communication with the IPyKernel
-            return
-    except NameError:
+            return  # Not ran from JupyterNotebook or similar
+    except NameError:  # Not ran from IPython
         raise RuntimeError("`run_notebook` can only be run from within a jupyter notebook!")
     connection_file = os.path.basename(ipykernel.get_connection_file())
     # Connection file is e.g. /run/user/1000/jupyter/kernel-c5f9d570-3c1c-4ef9-b3b9-d8de11ce4d0c.json
@@ -23,7 +21,7 @@ def run_notebook():
     kernel_id = os.path.splitext(connection_file)[0].split('-', 1)[1]
     for srv in notebookapp.list_running_servers():
         url = srv['url'] + "api/sessions"
-        if srv['password']:
+        if srv['password']:  # Password-protected, how do we access using GET/POST?
             print("Skipping notebook server on port {port} as it's password-protected".format(port=srv['port']))
             continue
         if srv['token']:
@@ -33,6 +31,5 @@ def run_notebook():
         for sess in sessions:
             if sess['kernel']['id'] == kernel_id:
                 path = os.path.join(srv['notebook_dir'], sess['notebook']['path'])
-                _get_api().submit((path,))
-                return
-
+                _get_api().submit((path,))  # Submit notebook
+                return  # Stops looping

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -21,7 +21,7 @@ def submit_notebook(job_name: str = None, poll_interval: Optional[float] = None,
     """
     try:
         try:
-            get_ipython_func = get_ipython
+            get_ipython_func = get_ipython  # type: ignore
         except NameError:
             get_ipython_func = None
         path = _get_notebook_path_generic(get_ipython_function=get_ipython_func,

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -21,6 +21,8 @@ def submit_notebook(job_name: str = None, poll_interval: Optional[float] = None,
     """
     try:
         try:
+            # ignoring Mypy static type checking as `get_ipython` will only be dynamically defined if the calling script
+            # was run from ipython shell (terminal or ZMQ based)
             get_ipython_func = get_ipython  # type: ignore
         except NameError:
             get_ipython_func = None

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -1,35 +1,96 @@
+from typing import Optional
 import os
+import logging
+from http import HTTPStatus
+
+import requests
 import ipykernel
 from notebook import notebookapp
-import requests
 
-from ..__utils__ import _get_api
+from ..core.service import Service
 
-__all__ = ["run_notebook"]
+__all__ = ["submit_notebook"]
 
+LOGGER = logging.getLogger(__file__)
 
-def run_notebook():
+def submit_notebook(job_name: str = None, poll_interval: Optional[float] = None, notebook_password: str = None):
+    """
+    Submits the current notebook to the Meeshkan agent. Requires the agent to be running.
+    Can only be called from within a notebook instance.
+    On password-protected notebooks, the `password` argument must be supplied a-priori.
+    """
     try:  # Verifies this was run in an IPython with a non-terminal kernel
-        ip = get_ipython()
-        if ip.__class__.__name__ != "ZMQInteractiveShell":  # Used for communication with the IPyKernel
-            return  # Not ran from JupyterNotebook or similar
+        ipython = get_ipython()  # type: ignore
+        if ipython.__class__.__name__ != "ZMQInteractiveShell":  # Used for communication with the IPyKernel
+            # This is only meant to run from Jupyter Notebook; once converted by Meeshkan, it may potentially run with
+            # ipython interpreter, so `get_ipython()` will exist but will be 'TerminalInteractiveShell' instead.
+            return
     except NameError:  # Not ran from IPython
         raise RuntimeError("`run_notebook` can only be run from within a jupyter notebook!")
+
     connection_file = os.path.basename(ipykernel.get_connection_file())
     # Connection file is e.g. /run/user/1000/jupyter/kernel-c5f9d570-3c1c-4ef9-b3b9-d8de11ce4d0c.json
     # kernel id is then c5f9d570-3c1c-4ef9-b3b9-d8de11ce4d0c
+    # responses from Jupyter Notebook API are described here:
+    # pylint: disable=line-too-long
+    #     http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml
     kernel_id = os.path.splitext(connection_file)[0].split('-', 1)[1]
     for srv in notebookapp.list_running_servers():
-        url = srv['url'] + "api/sessions"
-        if srv['password']:  # Password-protected, how do we access using GET/POST?
-            print("Skipping notebook server on port {port} as it's password-protected".format(port=srv['port']))
+        sessions_url = "{url}api/sessions".format(url=srv['url'])
+        sess = _notebook_authenticated_session_or_none(base_url=srv['url'], uses_password=srv['password'],
+                                                       port=srv['port'], notebook_password=notebook_password)
+        if sess is None:
             continue
-        if srv['token']:
-            url += "?token={token}".format(token=srv["token"])
 
-        sessions = requests.get(url).json()
-        for sess in sessions:
-            if sess['kernel']['id'] == kernel_id:
-                path = os.path.join(srv['notebook_dir'], sess['notebook']['path'])
-                _get_api().submit((path,))  # Submit notebook
+        if srv['token']:
+            sessions_url += "?token={token}".format(token=srv["token"])
+
+        nb_sessions = sess.get(sessions_url).json()
+        for nb_sess in nb_sessions:
+            if nb_sess['kernel']['id'] == kernel_id:
+                path = os.path.join(srv['notebook_dir'], nb_sess['notebook']['path'])
+                Service.api().submit((path,), name=job_name, poll_interval=poll_interval)  # Submit notebook
                 return  # Stops looping
+
+
+def _notebook_authenticated_session_or_none(base_url: str, uses_password: bool, port: int,
+                                            notebook_password: str = None) -> Optional[requests.Session]:
+    """Attempts to create a new requests.Session with access to the Notebook Server API:
+            https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API
+        This function does not handle token-based access.
+
+        This function does not raise; instead, it prints any errors and returns None, failing silently.
+
+        :param base_url: base URL to access notebook server API
+        :param uses_password: whether the notebook server uses password protection
+        :param port: port used in the base URL; used for prints
+        :param notebook_password: the password to use in password protected servers (optional)
+        :return authenticated requests.Session with access to the API, or None if fails.
+    """
+    login_url = "{url}login".format(url=base_url)
+    sess = requests.Session()
+    if not uses_password:
+        return sess
+
+    if notebook_password is None:
+        print("Skipping notebook server on port {port} as it's password-protected".format(port=port))
+        return None
+
+    # Cookie authorization
+
+    # 1. get the cookie xsrf from the login page
+    res = sess.get(login_url)
+    filtered_res = [line for line in res.text.splitlines() if "_xsrf" in line]
+    if len(filtered_res) != 1:
+        logging.warning("Multiple xsrf cookie fields found in notebook loging page!")
+        return None
+    # Break the relevant line; it looks like this: <input type="hidden" name="_xsrf" value="..."/>
+    xsrf = filtered_res[0].split("\"")[-2]
+
+    # 2. attempt to authenticate
+    res = sess.post(login_url, data={"_xsrf": xsrf, "password": notebook_password})
+    if res.status_code != HTTPStatus.OK:
+        print("Cannot authenticate to notebook server on port {port}! Did you provide the correct "
+              "password? Skipping...".format(port=port))
+        return None
+    return sess

--- a/meeshkan/api/utils.py
+++ b/meeshkan/api/utils.py
@@ -1,3 +1,38 @@
 from typing import List
+import os
+import ipykernel
+from notebook import notebookapp
+import requests
+import json
 
-__all__ = []  # type: List[str]
+from ..__utils__ import _get_api
+
+__all__ = ["run_notebook"]  # type: List[str]
+
+
+def run_notebook():
+    try:
+        ip = get_ipython()  # Verifies this was run in Jupyter
+        if ip.__class__.__name__ != "ZMQInteractiveShell":  # Used for communication with the IPyKernel
+            return
+    except NameError:
+        raise RuntimeError("`run_notebook` can only be run from within a jupyter notebook!")
+    connection_file = os.path.basename(ipykernel.get_connection_file())
+    # Connection file is e.g. /run/user/1000/jupyter/kernel-c5f9d570-3c1c-4ef9-b3b9-d8de11ce4d0c.json
+    # kernel id is then c5f9d570-3c1c-4ef9-b3b9-d8de11ce4d0c
+    kernel_id = os.path.splitext(connection_file)[0].split('-', 1)[1]
+    for srv in notebookapp.list_running_servers():
+        url = srv['url'] + "api/sessions"
+        if srv['password']:
+            print("Skipping notebook server on port {port} as it's password-protected".format(port=srv['port']))
+            continue
+        if srv['token']:
+            url += "?token={token}".format(token=srv["token"])
+
+        sessions = requests.get(url).json()
+        for sess in sessions:
+            if sess['kernel']['id'] == kernel_id:
+                path = os.path.join(srv['notebook_dir'], sess['notebook']['path'])
+                _get_api().submit((path,))
+                return
+

--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -171,8 +171,7 @@ class Scheduler:
         active_jobs = [job for job in jobs if self.active_external_job_id == job.id]
         if not active_jobs:
             return jobs[0].id
-        else:
-            return active_jobs[0].id
+        return active_jobs[0].id
 
     def add_condition(self, pid: int, *vals: str, condition: Callable[[float], bool], only_relevant: bool):
         """Adds a new condition for a job that matches the given process id.

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -167,6 +167,6 @@ class Service:
             self.terminate_daemon_event.set()  # Flag for requestLoop to terminate
             with Service._pyro_proxy() as pyro_proxy:
                 # triggers checking loopCondition
-                pyro_proxy._pyroBind()  # pylint: disable=protected-acces
+                pyro_proxy._pyroBind()  # pylint: disable=protected-access
             return True
         return False

--- a/meeshkan/exceptions.py
+++ b/meeshkan/exceptions.py
@@ -48,3 +48,9 @@ class DeferredImportException:
 class AgentNotAvailableException(Exception):
     def __index__(self):
         super().__init__("Start the agent first.")
+
+
+class MismatchingIPythonKernelException(Exception):
+    def __init__(self, found_kernel_type, expected_kernel_type):
+        super().__init__("Found an IPython kernel, but it doesn't match the expected type (found {found},"
+                         "expected {expected}".format(found=found_kernel_type, expected=expected_kernel_type))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ SRC_DIR = 'meeshkan'  # Relative location wrt setup.py
 # Required packages.
 # Older version of requests because >= 2.21 conflicts with sagemaker.
 REQUIRED = ['boto3', 'dill', 'requests<2.21', 'Click', 'pandas', 'Pyro4', 'PyYAML', 'tabulate', 'matplotlib',
-            'nbconvert']
+            'nbconvert', 'ipykernel', 'notebook']
 
 DEV = ['jupyter', 'nbdime', 'pylint', 'pytest==4.0.2', 'pytest-cov', 'mypy', 'pytest-asyncio', 'sagemaker', 'sphinx',
        'sphinx-click', 'sphinx_rtd_theme']

--- a/tests/resources/kernel-1234-5768-90ab-cdef.json
+++ b/tests/resources/kernel-1234-5768-90ab-cdef.json
@@ -1,0 +1,1 @@
+{"content": "dummy"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -398,7 +398,7 @@ class TestNotebookPathDiscovery:
     def test_from_notebook_ipython_no_connection_file(self):
         with pytest.raises(RuntimeError):
             _get_notebook_path_generic(get_ipython_function=self.get_valid_shell, list_servers_function=lambda: list(),
-                                       connection_file_function=self.get_kernel_file)
+                                       connection_file_function=lambda: "")
 
     def test_from_notebook_ipython(self):
         token = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,12 @@ import time
 from http import HTTPStatus
 from typing import Callable
 from unittest import mock
+from typing import Optional
+import sys
+import subprocess
 
+from IPython.terminal.ipapp import launch_new_instance
+from notebook.auth import passwd
 import requests
 from meeshkan.notifications.notifiers import Notifier
 from meeshkan.core.job import Job
@@ -98,3 +103,54 @@ def wait_for_true(func, timeout=FUTURE_TIMEOUT):
         if slept > timeout:
             raise Exception("Wait timeout for func {func}".format(func=func))
 
+
+class NBServer:
+    def __init__(self, ip: str, port: int, key: str = "", use_password: bool = False):
+        self.ip = ip
+        self.port = port
+        self.key = key
+        self.use_password = use_password
+        self.server = None  # type: Optional[subprocess.Popen]
+
+    @property
+    def url(self):
+        return "http://{ip}:{port}/".format(ip=self.ip, port=self.port)
+
+    def __enter__(self):
+        self._start_local_jupyter_server()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.server is not None:
+            self.server.terminate()
+            self.server = None
+
+    def _start_local_jupyter_server(self):
+        """Starts a local instance of a jupyter notebook server with given key as token or password.
+        It is up to the calling method to terminate the process.
+        """
+        if self.use_password:
+            notebook_security = "'--NotebookApp.password={password}'".format(password=passwd(self.key))
+        else:
+            notebook_security = "'--NotebookApp.token={token}'".format(token=self.key)
+        self.server = subprocess.Popen(["python", "-c", "from IPython.terminal.ipapp import launch_new_instance; "
+                                                         "import sys;"
+                                                         "sys.argv = ['jupyter', 'notebook', "
+                                                                     "'--IPKernelApp.pylab=inline', "
+                                                                     "'--NotebookApp.open_browser=False', {security},"
+                                                                     "'--NotebookApp.port={port}', "
+                                                                     "'--NotebookApp.ip={ip}'];"
+                                                         "launch_new_instance()".format(ip=self.ip, port=self.port,
+                                                                                        security=notebook_security)],
+                                       stdout=subprocess.PIPE)
+        if self.server.poll() is not None:
+            raise RuntimeError("Could not start jupyter notebook!")
+
+        # Wait until server is up:
+        server_is_up = False
+        sleep_time = 0.1  # seconds between polling for process to finish
+        while not server_is_up:
+            check_server_proc = subprocess.Popen(["jupyter", "notebook", "list"], stdout=subprocess.PIPE)
+            while check_server_proc.poll() is None:  # Process is still ongoing
+                time.sleep(sleep_time)
+            server_is_up = self.url in check_server_proc.stdout.read().decode()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -137,9 +137,10 @@ class NBServer:
                                                          "import sys;"
                                                          "sys.argv = ['jupyter', 'notebook', "
                                                                      "'--IPKernelApp.pylab=inline', "
-                                                                     "'--NotebookApp.open_browser=False', {security},"
+                                                                     "'--NotebookApp.open_browser=False', {security}, "
                                                                      "'--NotebookApp.port={port}', "
-                                                                     "'--NotebookApp.ip={ip}'];"
+                                                                     "'--NotebookApp.ip={ip}', "
+                                                                     "'--NotebookApp.log_level=CRITICAL'];"
                                                          "launch_new_instance()".format(ip=self.ip, port=self.port,
                                                                                         security=notebook_security)],
                                        stdout=subprocess.PIPE)


### PR DESCRIPTION
Adds the ability to send the notebook to the agent without interacting with the CLI.
Notebook does not freeze but will not get output from the run either.
- [x] Add tests
- [x] Add documentation