### PR TITLE
CLI: 'submit' as default subcommand if no subcommand is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Submit the example job with 10 second reporting interval:
 ```bash
 $ meeshkan submit --name report-example --report-interval 10 report.py
 ```
+For ease of use, we also offer the shorthand:
+```bash
+$ meeshkan --name report-example --report-interval 10 report.py
+```
+**Notice**: this shorthand only works if the file (in this case, `report.py`) actually exists.  
 If you setup Slack integration in [meeshkan.com](https://www.meeshkan.com),
 you should receive a notification for job being started. You should get notifications every ten seconds. The script
 runs for 20 seconds, so you should get one notification containing scalar values.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ $ meeshkan submit --name report-example --report-interval 10 report.py
 For ease of use, we also offer the shorthand:
 ```bash
 $ meeshkan --name report-example --report-interval 10 report.py
-```
-**Notice**: this shorthand only works if the file (in this case, `report.py`) actually exists.  
+```  
 If you setup Slack integration in [meeshkan.com](https://www.meeshkan.com),
 you should receive a notification for job being started. You should get notifications every ten seconds. The script
 runs for 20 seconds, so you should get one notification containing scalar values.

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -34,7 +34,16 @@ LOGGER = None
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+class DefGroup(click.Group):
+    DEF_CMD = ["submit"]
+
+    def resolve_command(self, ctx, args):
+        try:
+            return super().resolve_command(ctx, args)
+        except click.UsageError:
+            return super().resolve_command(ctx, DefGroup.DEF_CMD + args)
+
+@click.group(context_settings=CONTEXT_SETTINGS, cls=DefGroup)
 @click.version_option(version=meeshkan.__version__)
 @click.option("--debug", is_flag=True)
 @click.option("--silent", is_flag=True)

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -31,24 +31,28 @@ from .agent import start as start_agent
 
 LOGGER = None
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'], ignore_unknown_options=True)
 
 
 class DefGroup(click.Group):
-    DEF_CMD = ["submit"]
+    DEF_CMD = "submit"
 
     def resolve_command(self, ctx, args):
-        try:
-            return super().resolve_command(ctx, args)
-        except click.UsageError:
-            return super().resolve_command(ctx, DefGroup.DEF_CMD + args)
+        for arg in args:
+            if os.path.isfile(arg):
+                args.insert(0, DefGroup.DEF_CMD)
+                break
+        return super().resolve_command(ctx, args)
 
 @click.group(context_settings=CONTEXT_SETTINGS, cls=DefGroup)
 @click.version_option(version=meeshkan.__version__)
 @click.option("--debug", is_flag=True)
 @click.option("--silent", is_flag=True)
 def cli(debug, silent):
-    """Command-line interface for working with the Meeshkan agent."""
+    """
+    Command-line interface for working with the Meeshkan agent.
+    If no COMMAND is given, it is assumed to be `submit`.
+    """
     if not debug:
         sys.tracebacklimit = 0
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -226,7 +226,7 @@ def test_start_submit(pre_post_tests):  # pylint: disable=unused-argument,redefi
     assert start_result.exit_code == 0, "`start` should run smoothly"
     assert Service.is_running(), "Service should be running after `start`"
 
-    submit_result = run_cli(args='submit echo Hello')
+    submit_result = run_cli(args='echo Hello')  # if it works without the `submit`, it will work with it
     assert submit_result.exit_code == 0, "`submit` is expected to succeed"
 
     stdout_pattern = r"Job\s(\d+)\ssubmitted\ssuccessfully\swith\sID\s([\w-]+)"


### PR DESCRIPTION
Assuming `meeshkan submit ...` is the most common task and perhaps the least docker-like (should we change `submit` to `run` or `exec` to match a better known CLI format?), then it might make sense to make this the default.
Since scripts are run locally with `python <script>`, this allows to run the scripts with `meeshkan <script>`, while maintaining the CLI layout.