### PR TITLE
Add blocking job decorator tests

### DIFF
--- a/meeshkan/api/external_job.py
+++ b/meeshkan/api/external_job.py
@@ -81,16 +81,16 @@ def create_blocking_job(name: str, report_interval_secs: Optional[float] = None)
     :return: Meeshkan blocking job
     """
     pid = os.getpid()
-    with meeshkan.Service.api() as proxy:  # type: Api
+    with meeshkan.__utils__._get_api() as proxy:  # type: Api
         job_id = proxy.external_jobs.create_external_job(pid=pid, name=name, poll_interval=report_interval_secs)
         return ExternalJobWrapper(job_id=job_id)
 
 
 def register_external_job(job_id: uuid.UUID):
-    with meeshkan.Service.api() as proxy:  # type: Api
+    with meeshkan.__utils__._get_api() as proxy:  # type: Api
         proxy.external_jobs.register_active_external_job(job_id=job_id)
 
 
 def unregister_external_job(job_id: uuid.UUID):
-    with meeshkan.Service.api() as proxy:  # type: Api
+    with meeshkan.__utils__._get_api() as proxy:  # type: Api
         proxy.external_jobs.unregister_active_external_job(job_id=job_id)

--- a/meeshkan/api/external_job.py
+++ b/meeshkan/api/external_job.py
@@ -2,7 +2,8 @@ from functools import wraps
 import os
 from typing import Optional
 import uuid
-from ..core.service import Service
+
+import meeshkan
 from ..core.api import Api
 
 __all__ = ["create_blocking_job", "as_blocking_job"]
@@ -80,16 +81,16 @@ def create_blocking_job(name: str, report_interval_secs: Optional[float] = None)
     :return: Meeshkan blocking job
     """
     pid = os.getpid()
-    with Service.api() as proxy:  # type: Api
+    with meeshkan.Service.api() as proxy:  # type: Api
         job_id = proxy.external_jobs.create_external_job(pid=pid, name=name, poll_interval=report_interval_secs)
         return ExternalJobWrapper(job_id=job_id)
 
 
 def register_external_job(job_id: uuid.UUID):
-    with Service.api() as proxy:  # type: Api
+    with meeshkan.Service.api() as proxy:  # type: Api
         proxy.external_jobs.register_active_external_job(job_id=job_id)
 
 
 def unregister_external_job(job_id: uuid.UUID):
-    with Service.api() as proxy:  # type: Api
+    with meeshkan.Service.api() as proxy:  # type: Api
         proxy.external_jobs.unregister_active_external_job(job_id=job_id)

--- a/meeshkan/api/external_job.py
+++ b/meeshkan/api/external_job.py
@@ -3,7 +3,7 @@ import os
 from typing import Optional
 import uuid
 
-import meeshkan
+from ..core.service import Service
 from ..core.api import Api
 
 __all__ = ["create_blocking_job", "as_blocking_job"]
@@ -81,16 +81,16 @@ def create_blocking_job(name: str, report_interval_secs: Optional[float] = None)
     :return: Meeshkan blocking job
     """
     pid = os.getpid()
-    with meeshkan.__utils__._get_api() as proxy:  # type: Api
+    with Service.api() as proxy:  # type: Api
         job_id = proxy.external_jobs.create_external_job(pid=pid, name=name, poll_interval=report_interval_secs)
         return ExternalJobWrapper(job_id=job_id)
 
 
 def register_external_job(job_id: uuid.UUID):
-    with meeshkan.__utils__._get_api() as proxy:  # type: Api
+    with Service.api() as proxy:  # type: Api
         proxy.external_jobs.register_active_external_job(job_id=job_id)
 
 
 def unregister_external_job(job_id: uuid.UUID):
-    with meeshkan.__utils__._get_api() as proxy:  # type: Api
+    with Service.api() as proxy:  # type: Api
         proxy.external_jobs.unregister_active_external_job(job_id=job_id)

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -21,7 +21,7 @@ DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
 
 
 # Do not expose anything by default (internal module)
-__all__ = ["Service"]  # type: List[str]
+__all__ = []  # type: List[str]
 
 
 def _platform_is_darwin() -> bool:

--- a/meeshkan/core/service.py
+++ b/meeshkan/core/service.py
@@ -21,7 +21,7 @@ DAEMON_BOOT_WAIT_TIME = 2.0  # In seconds
 
 
 # Do not expose anything by default (internal module)
-__all__ = []  # type: List[str]
+__all__ = ["Service"]  # type: List[str]
 
 
 def _platform_is_darwin() -> bool:

--- a/tests/test_external_jobs.py
+++ b/tests/test_external_jobs.py
@@ -1,0 +1,38 @@
+from unittest import mock
+
+import meeshkan
+
+JOB_NAME = "test-job"
+
+
+def test_as_blocking_job_calls_function_with_correct_arguments():
+    function_called = False
+
+    function_args = [1]
+    function_kwargs = {'a': 2}
+
+    @meeshkan.as_blocking_job(job_name=JOB_NAME, report_interval_secs=60)
+    def func(*args, **kwargs):
+        nonlocal function_called
+        function_called = True
+
+        assert len(args) == len(function_args)
+        assert args[0] == function_args[0]
+
+        assert kwargs == function_kwargs
+
+    with mock.patch('meeshkan.Service'):
+        func(*function_args, **function_kwargs)
+
+    assert function_called
+
+
+def test_as_blocking_job_calls_service_api():
+
+    @meeshkan.as_blocking_job(job_name=JOB_NAME, report_interval_secs=60)
+    def func():
+        return
+
+    with mock.patch('meeshkan.Service') as mock_service:
+        func()
+        assert mock_service.api.call_count == 3, "Expected Service.api to have been called thrice"

--- a/tests/test_external_jobs.py
+++ b/tests/test_external_jobs.py
@@ -21,7 +21,7 @@ def test_as_blocking_job_calls_function_with_correct_arguments():
 
         assert kwargs == function_kwargs
 
-    with mock.patch('meeshkan.Service'):
+    with mock.patch('meeshkan.__utils__._get_api'):
         func(*function_args, **function_kwargs)
 
     assert function_called
@@ -33,6 +33,6 @@ def test_as_blocking_job_calls_service_api():
     def func():
         return
 
-    with mock.patch('meeshkan.Service') as mock_service:
+    with mock.patch('meeshkan.__utils__._get_api') as mock_get_api:
         func()
-        assert mock_service.api.call_count == 3, "Expected Service.api to have been called thrice"
+        assert mock_get_api.call_count == 3, "Expected Service.api to have been called thrice"


### PR DESCRIPTION
- Use `meeshkan.__utils__._get_api` to get the API as it's easy to mock/patch without exposing `meeshkan.Service`
- Add quick smoke tests for the blocking job