### PR TITLE
Correctly search for the job by ID.

### DIFF
--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -183,7 +183,7 @@ class Scheduler:
             this condition is met
         """
         job_id = self.__get_job_by_pid(pid)
-        job = self.get_job_by_id(job_id=job_id):
+        job = self.get_job_by_id(job_id=job_id)
         job.add_condition(*vals, condition=condition, only_relevant=only_relevant)
 
     def report_scalar(self, pid, name, val):

--- a/meeshkan/core/scheduler.py
+++ b/meeshkan/core/scheduler.py
@@ -183,7 +183,8 @@ class Scheduler:
             this condition is met
         """
         job_id = self.__get_job_by_pid(pid)
-        self.submitted_jobs[job_id].add_condition(*vals, condition=condition, only_relevant=only_relevant)
+        job = self.get_job_by_id(job_id=job_id):
+        job.add_condition(*vals, condition=condition, only_relevant=only_relevant)
 
     def report_scalar(self, pid, name, val):
         # Find the right job id


### PR DESCRIPTION
Adding conditions did not work for external jobs aka blocking jobs as the job was not correctly looked up with the ID.