### PR TITLE
[Feat] CreateGitHubJob Task from cloud

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -142,7 +142,7 @@ def report(job_identifier):
     ``JOB_IDENTIFIER`` is either the job's ID, number, name, or pattern to match against the job's name.
     """
     api = _get_api()
-    job_id = __find_job_by_identifier(job_identifier)
+    job_id = api.find_job_id_by_identifier(job_identifier)
     if not job_id:
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
@@ -188,11 +188,11 @@ def cancel_job(job_identifier):
 
     ``JOB_IDENTIFIER`` is either the job's ID, number, name, or pattern to match against the job's name.
     """
-    job_id = __find_job_by_identifier(job_identifier)
+    api = _get_api()
+    job_id = api.find_job_id_by_identifier(job_identifier)
     if not job_id:
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
-    api = _get_api()
     job = api.get_job(job_id)  # type: Job
     if job.status.is_running:
         res = input("Job '{name}' is currently running! "
@@ -201,7 +201,7 @@ def cancel_job(job_identifier):
             print("Aborted")
             sys.exit(2)
     api.cancel_job(job_id)
-    print("Canceled '{name}'".format(name=api.get_job(job_id).name))
+    print("Canceled '{name}'".format(name=job.name))
 
 
 @cli.command()
@@ -242,7 +242,7 @@ def logs(job_identifier):
     ``JOB_IDENTIFIER`` is either the job's ID, number, name, or pattern to match against the job's name.
     """
     api = _get_api()
-    job_id = __find_job_by_identifier(job_identifier)
+    job_id = api.find_job_id_by_identifier(job_identifier)
     if not job_id:
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
@@ -267,7 +267,7 @@ def notifications(job_identifier):
     ``JOB_IDENTIFIER`` is either the job's ID, number, name, or pattern to match against the job's name.
     """
     api = _get_api()
-    job_id = __find_job_by_identifier(job_identifier)
+    job_id = api.find_job_id_by_identifier(job_identifier)
     if not job_id:
         print("Can't find job with given identifier {identifier}".format(identifier=job_identifier))
         sys.exit(1)
@@ -343,30 +343,6 @@ def im_bored():
     author = os.path.splitext(os.path.basename(source))[0].capitalize()  # Create "Author"
     res = requests.get(source).text.split('\n')  # Get the document and split per line
     print("{}: \"{}\"".format(author, res[random.randint(0, len(res)-1)]))  # Choose line at random
-
-
-def __find_job_by_identifier(identifier: str) -> Optional[uuid.UUID]:
-    """
-    Finds a job by accessing UUID, job numbers and job names.
-    Returns the actual job-id if matching. Otherwise returns None.
-    """
-    # Determine identifier type and search over scheduler
-    api = _get_api()
-    job_id = job_number = None
-    try:
-        job_id = uuid.UUID(identifier)
-    except ValueError:
-        pass
-
-    try:
-        job_number = int(identifier)
-        if job_number < 1:  # Only accept valid job numbers.
-            job_number = None
-    except ValueError:
-        pass
-
-    # Treat `identifier` as pattern by default (bottom priority when looking up anyway)
-    return api.find_job_id(job_id=job_id, job_number=job_number, pattern=identifier)
 
 
 if __name__ == '__main__':

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -13,6 +13,7 @@ from .scheduler import Scheduler
 from .service import Service
 from .tasks import TaskPoller, Task, TaskType
 from ..notifications.notifiers import Notifier
+from ..git import submit_git
 from ..__types__ import HistoryByScalar
 from .serializer import Serializer
 
@@ -104,20 +105,18 @@ class Api:
                      "(job ID {job_id}".format(job_id=task.job_id) if hasattr(task, 'job_id') else "")
         if task.type == TaskType.StopJobTask:
             self.scheduler.stop_job(task.job_id)
-        elif task.type == TaskType.CreateJobTask:
+        elif task.type == TaskType.CreateGitJobTask:
             """
             Fields should include:
-            args
-            cwd
             name  # Optional
+            repo
+            entry_point
+            branch  # Optional
+            commit_sha  # Optional
             poll_interval  # Optional
-            Git:  # Optional
-              repo
-              branch  # Optional
-              commit_sha  # Optional
-              entry_point  # Should be embodied in args
             """
-            pass
+            submit_git(repo=task.repo, entry_point=task.entry_point, branch=task.branch, commit_sha=task.commit_sha,
+                       job_name=task.job_name, report_interval_secs=task.report_interval)
 
     async def poll(self):
         if self.task_poller is not None:

--- a/meeshkan/core/api.py
+++ b/meeshkan/core/api.py
@@ -100,9 +100,24 @@ class Api:
         return ""
 
     async def handle_task(self, task: Task):
-        LOGGER.debug("Got task for job ID %s, task type %s", task.job_id, task.type.name)
+        LOGGER.debug("Got a new task of type %s %s", task.type.name,
+                     "(job ID {job_id}".format(job_id=task.job_id) if hasattr(task, 'job_id') else "")
         if task.type == TaskType.StopJobTask:
             self.scheduler.stop_job(task.job_id)
+        elif task.type == TaskType.CreateJobTask:
+            """
+            Fields should include:
+            args
+            cwd
+            name  # Optional
+            poll_interval  # Optional
+            Git:  # Optional
+              repo
+              branch  # Optional
+              commit_sha  # Optional
+              entry_point  # Should be embodied in args
+            """
+            pass
 
     async def poll(self):
         if self.task_poller is not None:

--- a/meeshkan/core/cloud.py
+++ b/meeshkan/core/cloud.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import requests
 
 from ..__types__ import Token, Payload
-from .tasks import TaskType, Task
+from .tasks import TaskFactory, Task
 from .oauth import TokenStore
 from ..exceptions import UnauthorizedRequestException
 from ..__version__ import __version__

--- a/meeshkan/core/cloud.py
+++ b/meeshkan/core/cloud.py
@@ -195,11 +195,7 @@ class CloudClient:
 
         tasks_json = data['popClientTasks']
 
-        def build_task(json_task):
-            task_type = TaskType[json_task['__typename']]
-            return Task(UUID(json_task['job']['id']), task_type=task_type)
-
-        tasks = [build_task(json_task) for json_task in tasks_json]
+        tasks = [TaskFactory.build(json_task) for json_task in tasks_json]
         return tasks
 
     def close(self):

--- a/meeshkan/core/tasks.py
+++ b/meeshkan/core/tasks.py
@@ -38,15 +38,34 @@ class StopTask(Task):
         return "for job that matches identifier {identifier}".format(identifier=self.job_identifier)
 
 
+class CreateGitJobTask(Task):
+    def __init__(self, repo: str, entry_point: str, commit_sha: str = None, branch: str = None,
+                 name: str = None, report_interval: float = None):
+        super().__init__(TaskType.CreateGitJobTask)
+        self.repo = repo
+        self.entry_point = entry_point
+        self.commit_sha = commit_sha
+        self.branch = branch
+        self.name = name
+        self.report_interval = report_interval
+
+    def describe(self):
+        return "running {entry} from {repo}/{branch}@{commit}".format(entry=self.entry_point, repo=self.repo,
+                                                                      branch=self.branch, commit=self.commit_sha)
+
+
 class TaskFactory:
     @staticmethod
     def build(json_task):
         task_type = TaskType[json_task['__typename']]
+        task_kw = json_task['job']
         if task_type == TaskType.StopJobTask:
-            return StopTask(job_identifier=json_task['job']['id'])
+            return StopTask(job_identifier=task_kw['id'])
         elif task_type == TaskType.CreateGitJobTask:
-            return
-        raise RuntimeError("Unrecognized task who dis")
+            return CreateGitJobTask(repo=task['repo'], entry_point=task_kw['entry_point'],
+                                    commit_sha=task_kw.get('commitSHA'), branch=task_kw.get('branch'),
+                                    name=task_kw.get('name'), report_interval=task_kw.get('reportInterval'))
+        raise RuntimeError("Unrecognized task who dis")  # IDAN TODO: update note ofcourse...
 
 
 class TaskPoller:

--- a/meeshkan/core/tasks.py
+++ b/meeshkan/core/tasks.py
@@ -15,13 +15,24 @@ __all__ = []  # type: List[str]
 
 class TaskType(Enum):
     StopJobTask = 0
-    CreateJobTask = 1
+    CreateGitJobTask = 1
 
 
 class Task:
-    def __init__(self, job_id: UUID, task_type: TaskType):
-        self.job_id = job_id
+    def __init__(self, task_type: TaskType, **kwargs):
         self.type = task_type
+        for key, value in kwargs:  # Add all keyword arguments as values
+            setattr(self, key, value)
+
+    def __getattr__(self, item):  # Don't raise any warnings for missing items, instead return None.
+        return getattr(self, item, None)
+
+
+class TaskFactory:
+    @staticmethod
+    def build(json_task):
+        task_type = TaskType[json_task['__typename']]
+        return Task(task_type=task_type, **{"job_id": UUID(json_task['job']['id'])})
 
 
 class TaskPoller:

--- a/meeshkan/core/tasks.py
+++ b/meeshkan/core/tasks.py
@@ -15,7 +15,7 @@ __all__ = []  # type: List[str]
 
 class TaskType(Enum):
     StopJobTask = 0
-    CreateGitJobTask = 1
+    CreateGitHubJobTask = 1
 
 
 class Task:
@@ -38,20 +38,19 @@ class StopTask(Task):
         return "for job that matches identifier {identifier}".format(identifier=self.job_identifier)
 
 
-class CreateGitJobTask(Task):
-    def __init__(self, repo: str, entry_point: str, commit_sha: str = None, branch: str = None,
-                 name: str = None, report_interval: float = None):
-        super().__init__(TaskType.CreateGitJobTask)
+class CreateGitHubJobTask(Task):
+    def __init__(self, repo: str, entry_point: str, branch_or_commit: str = None, name: str = None,
+                 report_interval: float = None):
+        super().__init__(TaskType.CreateGitHubJobTask)
         self.repo = repo
         self.entry_point = entry_point
-        self.commit_sha = commit_sha
-        self.branch = branch
+        self.branch_or_commit = branch_or_commit
         self.name = name
         self.report_interval = report_interval
 
     def describe(self):
-        return "running {entry} from {repo}/{branch}@{commit}".format(entry=self.entry_point, repo=self.repo,
-                                                                      branch=self.branch, commit=self.commit_sha)
+        return "running {entry} from {repo}@{branch_or_commit}".format(entry=self.entry_point, repo=self.repo,
+                                                                       branch_or_commit=self.branch_or_commit)
 
 
 class TaskFactory:
@@ -62,9 +61,9 @@ class TaskFactory:
         if task_type == TaskType.StopJobTask:
             return StopTask(job_identifier=task_kw['id'])
         elif task_type == TaskType.CreateGitJobTask:
-            return CreateGitJobTask(repo=task['repo'], entry_point=task_kw['entry_point'],
-                                    commit_sha=task_kw.get('commitSHA'), branch=task_kw.get('branch'),
-                                    name=task_kw.get('name'), report_interval=task_kw.get('reportInterval'))
+            return CreateGitHubJobTask(repo=task['repository'], entry_point=task_kw['entry_point'],
+                                       branch_or_commit=task_kw.get('branch_or_commit_sha'),
+                                       name=task_kw.get('name'), report_interval=task_kw.get('report_interval'))
         raise RuntimeError("Unrecognized task who dis")  # IDAN TODO: update note ofcourse...
 
 

--- a/meeshkan/core/tasks.py
+++ b/meeshkan/core/tasks.py
@@ -15,6 +15,7 @@ __all__ = []  # type: List[str]
 
 class TaskType(Enum):
     StopJobTask = 0
+    CreateJobTask = 1
 
 
 class Task:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from meeshkan.core.scheduler import Scheduler, QueueProcessor
 from meeshkan.core.service import Service
 from meeshkan.core.job import Job, JobStatus, SageMakerJob, ExternalJob
 from meeshkan.core.sagemaker_monitor import SageMakerJobMonitor
-from meeshkan.core.tasks import TaskType, Task
+from meeshkan.core.tasks import TaskType, TaskFactory
 from meeshkan.api.utils import _notebook_authenticated_session as nb_authenticate, submit_notebook, \
     _get_notebook_path_generic, submit_function
 
@@ -97,7 +97,7 @@ async def test_stopping_job_with_task(cleanup):  # pylint:disable=unused-argumen
         wait_for_true(lambda: job.status == JobStatus.RUNNING)
         # Schedule stop job task
         loop = asyncio.get_event_loop()
-        loop.create_task(api.handle_task(Task(job.id, TaskType.StopJobTask)))
+        loop.create_task(api.handle_task(TaskFactory.build({'__typename': 'StopJobTask', 'job': {'id': job.id}})))
         wait_for_true(scheduler._job_queue.empty)
 
     assert job.status in [JobStatus.CANCELLED_BY_USER, JobStatus.CANCELED]

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -101,7 +101,7 @@ def test_post_payloads_raises_error_for_multiple_401s():
 def test_pop_tasks():
     mock_session = mock.create_autospec(requests.Session, spec_set=True)
 
-    job_id = uuid.uuid4()
+    job_id = str(uuid.uuid4())
     task_name = 'StopJobTask'
 
     returned_task = {'job': {'id': str(job_id)}, '__typename': task_name}
@@ -121,7 +121,7 @@ def test_pop_tasks():
     assert len(tasks) == 1, "Hard-coded GraphQL query returns a strict single-item list. What happened?"
     created_task = tasks[0]
 
-    assert created_task.job_id == job_id, "The job ID for the task should reflect the original job_id after creating " \
-                                          "a proper Task object"
+    assert created_task.job_identifier == job_id, "The job ID for the task should reflect the original job_id after " \
+                                                  "creating a proper Task object"
     assert created_task.type.name == task_name, "The task typename should match the original typename after creating " \
                                                 "a proper Task object"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4,13 +4,13 @@ import queue
 
 import pytest
 
-from meeshkan.core.tasks import Task, TaskType, TaskPoller
+from meeshkan.core.tasks import StopTask, TaskType, TaskPoller
 
 
 @pytest.mark.asyncio
 async def test_task_poller_handles_tasks():
 
-    fake_task = Task(job_id='id', task_type=TaskType.StopJobTask)
+    fake_task = StopTask(job_identifier='id')
 
     def pop_tasks():
         return [fake_task]
@@ -43,11 +43,11 @@ async def test_task_poller_handles_tasks():
     # First handled item
     assert not handled_tasks.empty(), "Queue should contain two elements at this point"
     handled_item = handled_tasks.get()
-    assert handled_item.job_id == fake_task.job_id, "Handled item should be identical to the fake task"
+    assert handled_item.job_identifier == fake_task.job_identifier, "Handled item should be identical to the fake task"
 
     # Second handled item
     assert not handled_tasks.empty(), "Queue should contain one element at this point"
     handled_item = handled_tasks.get()
-    assert handled_item.job_id == fake_task.job_id, "Handled item should be identical to the fake task"
+    assert handled_item.job_identifier == fake_task.job_identifier, "Handled item should be identical to the fake task"
 
     assert handled_tasks.empty(), "Queue should be empty now"


### PR DESCRIPTION
Modifies the existing `Task` methods to allow for more elaborate incoming tasks. Adds the `CreateJobFromGit` task, which will be eventually invoked via e.g. `/mk-git` or similar.
Sets the groundwork for the upcoming addition (feature needs to be supported both in cloud and in client)

- [x] Add tests
- [x] Verify locally with local version of cloud