### PR TITLE
[Feat] Git: Deciding whether argument is branch name or commit SHA

### DIFF
--- a/meeshkan/git/utils.py
+++ b/meeshkan/git/utils.py
@@ -1,5 +1,5 @@
 """Provides utilities for pulling and parsing Git commits"""
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 import tempfile
 import shutil
 import os
@@ -12,7 +12,7 @@ from ..core.service import Service
 __all__ = ["submit_git"]
 
 
-def submit_git(repo: str, entry_point: str, branch: str = None, commit_sha: str = None,
+def submit_git(repo: str, entry_point: str, branch_or_commit: str = None,
                job_name: Optional[str] = None, report_interval_secs: Optional[float] = None):
     """Submits a GitHub repository as a job to the agent. The agent must be running.
 
@@ -27,7 +27,7 @@ def submit_git(repo: str, entry_point: str, branch: str = None, commit_sha: str 
         # A call with branch name would run the given branch from its most updated commit.
         meeshkan.git.submit(repo="Meeshkan/meeshkan-client",
                             entry_point="examples/pytorch_mnist.py",
-                            branch="dev",
+                            branch_or_commit="dev",
                             job_name="example #2",
                             report_interval_secs=10)
 
@@ -37,29 +37,21 @@ def submit_git(repo: str, entry_point: str, branch: str = None, commit_sha: str 
         # would be fine.
         meeshkan.git.submit(repo="Meeshkan/meeshkan-client",
                             entry_point="examples/pytorch_mnist.py",
-                            commit_sha="61657d7",
+                            branch_or_commit="61657d7",
                             job_name="example #3",
                             report_interval_secs=30)
 
-        # Branch and commit_sha may be used together, but commit SHA has precedence,
-        # so the following is identical to example #3:
-        meeshkan.git.submit(repo="Meeshkan/meeshkan-client",
-                            entry_point="examples/pytorch_mnist.py",
-                            branch="release-0.1.0",
-                            commit_sha="61657d7",
-                            job_name="identical to example #3")
-
     :param repo: A string describing a **GitHub** repository in plain <user or organization>/<repo name> format
     :param entry_point: A path (relevant to the repository) for the entry point (or file to run)
-    :param branch: Optional string, describing the branch on which to work (checkout the branch when cloning locally)
-    :param commit_sha: Optional string, a commit reference to reset to
+    :param branch_or_commit: Optional string, describing the either the branch to fork (checkout the branch when
+                                 cloning locally), or the commit SHA to use.
     :param job_name: Optional name to give to the job
     :param report_interval_secs: Optional float, notification report interval in seconds.
     :returns: :py:class:`Job` object
     """
     api = Service.api()  # Raise if agent is not running
     gitrunner = GitRunner(repo)
-    source_dir = gitrunner.pull_repo(branch=branch, commit_sha=commit_sha)
+    source_dir = gitrunner.pull_repo(branch_or_commit=branch_or_commit)
     return api.submit((os.path.join(source_dir, entry_point),), name=job_name, poll_interval=report_interval_secs)
 
 
@@ -70,19 +62,21 @@ class GitRunner:
             - Creates a temporary folder to store the git contents
         :param repo: The GitHub repository to pull, in a plain <user/organization>/<repo name> format
             # TODO: When we add more support, this should be parsed to include also full URLs etc
+            # TODO: And also modify url and authentication based on different sites...
         :return A tuple consisting of the access URL and the temporary folder path
         """
         GitRunner._verify_git_exists()
         self.repo = repo
         self.target_dir = tempfile.mkdtemp()
 
-    def pull_repo(self, branch: str = None, commit_sha: str = None) -> str:
+    def pull_repo(self, branch_or_commit: str = None) -> str:
         """Pulls a git repository to a temporary folder.
 
-        :param branch: An optional branch to download; pulls the repo and checkouts the given branch
-        :param commit_sha: An optional commit to revert to; pulls the repo/branch and hard resets to given commit
+        :param branch_or_commit: An optional branch to download (pulls the repo and checkouts the given branch) or an
+                                    optional commit to revert to (pulls the repo/branch and hard resets to given commit)
         :return The temporary folder with relevant pulled content
         """
+        commit_sha, branch = self._separate_to_commit_and_branch(branch_or_commit)
         args = ["git", "clone"]
         if branch is not None and commit_sha is None:  # Checkout the relevant branch (if commit not given)
             args += ["--depth", "1", "--branch", branch]
@@ -101,6 +95,28 @@ class GitRunner:
     def url(self):
         return "https://{token}:x-oauth-basic@github.com/{repo}".format(token=GitRunner._git_access_token(),
                                                                         repo=self.repo)
+
+    def _is_active_branch(self, branch_or_commit: str) -> bool:
+        """
+        Given a `branch_or_commit` argument, finds whether the argument is an active branch.
+        :param branch_or_commit:
+        """
+        # Get list of active remote branches
+        proc = Popen(["git", "ls-remote", self.url], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        GitRunner._wait_and_raise_on_error(proc)
+        result = [line.split("\t")[1] for line in proc.stdout.read().splitlines()]  # Returned list is SHA\tBranch name
+        return any([branch_or_commit in branch for branch in result])
+
+
+    def _separate_to_commit_and_branch(self, branch_or_commit) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Returns a tuple describing whether the given argument is an active branch or, by default, a commit SHA.
+        :return Tuple of (commit, branch), where one of the items is None and the other contains `branch_or_commit`.
+        """
+        if self._is_active_branch(branch_or_commit):
+            return None, branch_or_commit
+        return branch_or_commit, None
+
 
     @staticmethod
     def _git_access_token(credentials: Optional[Union[Path, str]] = None) -> str:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -54,7 +54,7 @@ def test_gitrunner_init(clean):
 
 def test_gitrunner_pull_branch(clean):
     gitrunner = GitRunner(repo=CLIENT_REPO)
-    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH)
+    gitrunner.pull_repo(branch_or_commit=FIRST_OFFICIAL_RELEASE_BRANCH)
     version_fname = os.path.join(gitrunner.target_dir, "meeshkan/__version__.py")
     try:
         assert os.path.isfile(version_fname)
@@ -66,24 +66,11 @@ def test_gitrunner_pull_branch(clean):
 
 def test_gitrunner_pull_commit(clean):
     gitrunner = GitRunner(repo=CLIENT_REPO)
-    gitrunner.pull_repo(commit_sha=FIRST_VERSION_COMMIT)
+    gitrunner.pull_repo(branch_or_commit=FIRST_VERSION_COMMIT)
     version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
     try:
         assert os.path.isfile(version_fname)
         with open(version_fname) as version_fd:
             assert version_fd.read() == "__version__ = \"0.0.1\"", "Commit SHA is expected to reset to matching version"
-    finally:
-        clean(gitrunner)
-
-
-def test_gitrunner_pull_branch_and_commit(clean):
-    gitrunner = GitRunner(repo=CLIENT_REPO)
-    gitrunner.pull_repo(branch=FIRST_OFFICIAL_RELEASE_BRANCH, commit_sha=FIRST_VERSION_COMMIT)
-    version_fname = os.path.join(gitrunner.target_dir, "client/__version__.py")
-    try:
-        assert os.path.isfile(version_fname)
-        with open(version_fname) as version_fd:
-            assert version_fd.read() == "__version__ = \"0.0.1\"", "When pulling a commit and a branch, commit SHA is" \
-                                                                   " expected to take precedence!"
     finally:
         clean(gitrunner)


### PR DESCRIPTION
To allow for easier use, both locally and remotely, and especially as we don't support the usage of both branch and commit SHA at the same time, they are united in a single parameter.
The parameter is then verified as an existing branch name using `git ls-remote` on the target repository.